### PR TITLE
Remove: Json from example.

### DIFF
--- a/examples/example-axum/src/docs.rs
+++ b/examples/example-axum/src/docs.rs
@@ -12,8 +12,9 @@ use axum::{
     response::{Html, IntoResponse},
     Extension,
 };
+use axum_jsonschema::Json;
 
-use crate::{extractors::Json, state::AppState};
+use crate::state::AppState;
 
 pub fn docs_routes(state: AppState) -> ApiRouter<AppState> {
     // We infer the return types for these routes

--- a/examples/example-axum/src/extractors.rs
+++ b/examples/example-axum/src/extractors.rs
@@ -1,29 +1,7 @@
-use aide::operation::OperationIo;
-use axum::response::IntoResponse;
 use axum_jsonschema::JsonSchemaRejection;
-use axum_macros::FromRequest;
-use serde::Serialize;
 use serde_json::json;
 
 use crate::errors::AppError;
-
-#[derive(FromRequest, OperationIo)]
-#[from_request(via(axum_jsonschema::Json), rejection(AppError))]
-#[aide(
-    input_with = "axum_jsonschema::Json<T>",
-    output_with = "axum_jsonschema::Json<T>",
-    json_schema
-)]
-pub struct Json<T>(pub T);
-
-impl<T> IntoResponse for Json<T>
-where
-    T: Serialize,
-{
-    fn into_response(self) -> axum::response::Response {
-        axum::Json(self.0).into_response()
-    }
-}
 
 impl From<JsonSchemaRejection> for AppError {
     fn from(rejection: JsonSchemaRejection) -> Self {

--- a/examples/example-axum/src/main.rs
+++ b/examples/example-axum/src/main.rs
@@ -6,9 +6,9 @@ use aide::{
     transform::TransformOpenApi,
 };
 use axum::{http::StatusCode, Extension};
+use axum_jsonschema::Json;
 use docs::docs_routes;
 use errors::AppError;
-use extractors::Json;
 use state::AppState;
 use todos::routes::todo_routes;
 use uuid::Uuid;

--- a/examples/example-axum/src/todos/routes.rs
+++ b/examples/example-axum/src/todos/routes.rs
@@ -10,11 +10,12 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use axum_jsonschema::Json;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{extractors::Json, state::AppState};
+use crate::state::AppState;
 
 use super::TodoItem;
 


### PR DESCRIPTION
I found a great crate!!

I was building my own server based on the examples and it looks like the `crate::extractors::Json` defined in the examples is actually unnecessary and could be replaced by `axum_jsonschema::Json`.

I removed the type for those who will touch the examples in the future.

If there is an intention and it is necessary, I would like to know the reason.

Thank you.