### PR TITLE
Add: default response.

### DIFF
--- a/crates/aide/src/axum/routing.rs
+++ b/crates/aide/src/axum/routing.rs
@@ -78,6 +78,10 @@ macro_rules! method_router_chain_method {
             let mut operation = Operation::default();
             in_context(|ctx| {
                 I::operation_input(ctx, &mut operation);
+
+                for (code, res) in O::inferred_responses(ctx, &mut operation) {
+                    set_inferred_response(ctx, &mut operation, code, res);
+                }
             });
             self.operations.insert(stringify!($name), operation);
             self.router = self.router.$name(handler);

--- a/crates/aide/src/axum/routing.rs
+++ b/crates/aide/src/axum/routing.rs
@@ -137,8 +137,14 @@ macro_rules! method_router_top_level {
             let mut operation = Operation::default();
             in_context(|ctx| {
                 I::operation_input(ctx, &mut operation);
+
+                for (code, res) in O::inferred_responses(ctx, &mut operation) {
+                    set_inferred_response(ctx, &mut operation, code, res);
+                }
             });
+
             router.operations.insert(stringify!($name), operation);
+
             router
         }
 


### PR DESCRIPTION
`aide::axum::routing::get` generates a schema for the request, but does not generate a schema for the response.

So, I add the response schema in case of success.