### PR TITLE
Fix: openapi version serializer.

### DIFF
--- a/crates/aide/src/openapi/openapi.rs
+++ b/crates/aide/src/openapi/openapi.rs
@@ -88,7 +88,7 @@ mod serde_version {
     use serde::{Deserializer, Serialize, Serializer};
 
     pub fn serialize<S: Serializer>(version: &'static str, ser: S) -> Result<S::Ok, S::Error> {
-        version.serialize(ser)
+        if version.is_empty() { "3.1.0" } else { version }.serialize(ser)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(_ser: D) -> Result<&'static str, D::Error> {

--- a/crates/aide/src/openapi/openapi.rs
+++ b/crates/aide/src/openapi/openapi.rs
@@ -87,8 +87,8 @@ impl OpenApi {
 mod serde_version {
     use serde::{Deserializer, Serialize, Serializer};
 
-    pub fn serialize<S: Serializer>(_: &'static str, ser: S) -> Result<S::Ok, S::Error> {
-        "3.1.0".serialize(ser)
+    pub fn serialize<S: Serializer>(version: &'static str, ser: S) -> Result<S::Ok, S::Error> {
+        version.serialize(ser)
     }
 
     pub fn deserialize<'de, D: Deserializer<'de>>(_ser: D) -> Result<&'static str, D::Error> {


### PR DESCRIPTION
I am using [Swagger UI](https://swagger.io/tools/swagger-ui/) to generate OpenAPI static page, but it does not currently support [v3.1.0 of OpenAPI](https://github.com/swagger-api/swagger-ui/issues/5891).

Therefore, I need to explicitly set v3.0.0, but I would like to modify it to serialize the value of the structure, as the serializer will invalidate the change if the structure is overwritten.


