### PR TITLE
Suggestion: impl OperationOutput for Rejections.

### DIFF
--- a/crates/aide/src/axum/outputs.rs
+++ b/crates/aide/src/axum/outputs.rs
@@ -132,7 +132,7 @@ impl OperationOutput for JsonRejection {
     type Inner = Self;
 
     fn operation_response(ctx: &mut GenContext, operation: &mut Operation) -> Option<Response> {
-        Json::<String>::operation_response(ctx, operation)
+        String::operation_response(ctx, operation)
     }
 
     fn inferred_responses(

--- a/crates/aide/src/axum/outputs.rs
+++ b/crates/aide/src/axum/outputs.rs
@@ -141,10 +141,10 @@ impl OperationOutput for JsonRejection {
     ) -> Vec<(Option<u16>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
             Vec::from([
-                rejection_response(StatusCode::BAD_REQUEST, &res),
+                // rejection_response(StatusCode::BAD_REQUEST, &res),
                 rejection_response(StatusCode::PAYLOAD_TOO_LARGE, &res),
                 rejection_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, &res),
-                rejection_response(StatusCode::UNPROCESSABLE_ENTITY, &res),
+                // rejection_response(StatusCode::UNPROCESSABLE_ENTITY, &res),
             ])
         } else {
             Vec::new()

--- a/crates/aide/src/gen.rs
+++ b/crates/aide/src/gen.rs
@@ -72,7 +72,7 @@ pub fn extract_schemas(extract: bool) {
 ///
 /// Some frameworks might use `204` for empty responses, whereas
 /// others will set `200`.
-/// 
+///
 /// The default value depends on the framework feature.
 pub fn inferred_empty_response_status(status: u16) {
     in_context(|ctx| {
@@ -88,6 +88,13 @@ pub fn inferred_empty_response_status(status: u16) {
 pub fn infer_responses(infer: bool) {
     in_context(|ctx| {
         ctx.infer_responses = infer;
+    });
+}
+
+/// Output All error responses based on axum.
+pub fn all_error_responses(infer: bool) {
+    in_context(|ctx| {
+        ctx.all_error_responses = infer;
     });
 }
 
@@ -112,6 +119,8 @@ pub struct GenContext {
 
     pub(crate) infer_responses: bool,
 
+    pub(crate) all_error_responses: bool,
+
     /// Extract schemas.
     pub(crate) extract_schemas: bool,
 
@@ -127,7 +136,6 @@ pub struct GenContext {
 
 impl GenContext {
     fn new() -> Self {
-
         cfg_if! {
             if #[cfg(feature = "axum")] {
                 let no_content_status = 200;
@@ -141,6 +149,7 @@ impl GenContext {
                 SchemaSettings::draft07().with(|s| s.inline_subschemas = true),
             ),
             infer_responses: false,
+            all_error_responses: false,
             extract_schemas: false,
             show_error: default_error_filter,
             error_handler: None,


### PR DESCRIPTION
It would be meaningful for the API Client to output error responses (Status, ResponseBody) to OpenAPI for error handling.

As a simple example, I would implement OperationOutput to "JsonRejection".

But maybe I should work on the axum side instead of the aide.
It would be better to ask JsonRejection itself to tell what error codes it can return.
In that case, the modification of [composite_rejection!](https://github.com/tokio-rs/axum/blob/e0ef641e5fc12048b1632cf2feebddac19a2f8ad/axum/src/extract/rejection.rs#L123).

What do you think of this idea?