### PR TITLE
feat: expose underlying axum Router

### DIFF
--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -175,15 +175,7 @@ use crate::{
     util::merge_paths,
     OperationOutput,
 };
-use axum::{
-    body::{Body, HttpBody},
-    extract::connect_info::IntoMakeServiceWithConnectInfo,
-    handler::Handler,
-    http::Request,
-    response::IntoResponse,
-    routing::{IntoMakeService, Route},
-    Router, RouterService,
-};
+use axum::{body::{Body, HttpBody}, extract::connect_info::IntoMakeServiceWithConnectInfo, handler::Handler, http::Request, response::IntoResponse, routing::{IntoMakeService, Route}, Router, RouterService};
 use indexmap::IndexMap;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -300,6 +292,12 @@ where
     #[tracing::instrument(skip_all)]
     pub fn finish_api(mut self, api: &mut OpenApi) -> Router<S, B> {
         self.merge_api(api);
+        self.router
+    }
+
+    /// Get the underlying [`axum::Router`]
+    #[tracing::instrument(skip_all)]
+    pub fn inner(self) -> Router<S, B> {
         self.router
     }
 


### PR DESCRIPTION
I am not sure this is the best option but it's the only way I have found to be able to setup test with sqlx. 

## Example

```rust
#[sqlx::test]
async fn create_user(db: PgPool) -> eyre::Result<()> {
    let request = Request::post("/users")
        .header(CONTENT_TYPE, "application/json")
        .json(json! {{ "username": "alice" }});

    let mut response = service(db)
        .oneshot(request)
        .await?;

    assert_that!(response.status()).is_equal_to(StatusCode::NO_CONTENT);
    Ok(())
}

fn service(db: PgPool) -> RouterService {
    app::app(db)
        .inner()
        .into_service()
}
```