### PR TITLE
feat(aide): Update to axum 0.6.0-rc.5

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide"
-version = "0.7.1"
+version = "0.8.0-rc.1"
 authors = ["tamasfe"]
 edition = "2021"
 keywords = ["generate", "api", "openapi", "documentation", "specification"]
@@ -21,8 +21,8 @@ aide-macros = { version = "0.6.0", path = "../aide-macros", optional = true }
 bytes = { version = "1", optional = true }
 http = { version = "0.2", optional = true }
 
-axum = { version = "0.6.0-rc.1", optional = true }
-axum-extra = { version = "0.4.0-rc.1", optional = true }
+axum = { version = "0.6.0-rc.5", optional = true }
+axum-extra = { version = "0.4.0-rc.2", optional = true }
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 cfg-if = "1.0.0"

--- a/crates/axum-jsonschema/Cargo.toml
+++ b/crates/axum-jsonschema/Cargo.toml
@@ -10,7 +10,7 @@ description = "Request JSON schema validation for axum"
 readme = "README.md"
 
 [dependencies]
-aide = { version = "0.7.0", path = "../aide", optional = true, features = [
+aide = { version = "0.8.0-rc.1", path = "../aide", optional = true, features = [
     "axum",
 ] }
 async-trait = "0.1.57"

--- a/examples/example-axum/src/docs.rs
+++ b/examples/example-axum/src/docs.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use aide::{
     axum::{
         routing::{get, get_with},
-        ApiRouter, IntoApiResponse,
+        ApiRouter, ApiRouterService, IntoApiResponse,
     },
     openapi::OpenApi,
 };
@@ -15,7 +15,7 @@ use axum::{
 
 use crate::{extractors::Json, state::AppState};
 
-pub fn docs_routes(state: AppState) -> ApiRouter<AppState> {
+pub fn docs_routes(state: AppState) -> ApiRouterService {
     // We infer the return types for these routes
     // as an example.
     //
@@ -24,13 +24,14 @@ pub fn docs_routes(state: AppState) -> ApiRouter<AppState> {
     // with a 200 status.
     aide::gen::infer_responses(true);
 
-    let router = ApiRouter::with_state(state)
+    let router = ApiRouter::new()
         .api_route_with(
             "/",
             get_with(serve_redoc, |op| op.description("This documentation page.")),
             |p| p.security_requirement("ApiKey"),
         )
-        .route("/private/api.json", get(serve_docs));
+        .route("/private/api.json", get(serve_docs))
+        .with_state(state);
 
     // Afterwards we disable response inference because
     // it might be incorrect for other routes.

--- a/examples/example-axum/src/main.rs
+++ b/examples/example-axum/src/main.rs
@@ -31,11 +31,12 @@ async fn main() {
 
     let mut api = OpenApi::default();
 
-    let app = ApiRouter::with_state(state.clone())
-        .nest("/todo", todo_routes(state.clone()))
-        .nest("/docs", docs_routes(state))
+    let app = ApiRouter::new()
+        .nest_api_service("/todo", todo_routes(state.clone()))
+        .nest_api_service("/docs", docs_routes(state.clone()))
         .finish_api_with(&mut api, api_docs)
-        .layer(Extension(Arc::new(api)));
+        .layer(Extension(Arc::new(api)))
+        .with_state(state);
 
     println!("Example docs are accessible at http://127.0.0.1:3000/docs");
 

--- a/examples/example-axum/src/todos/routes.rs
+++ b/examples/example-axum/src/todos/routes.rs
@@ -1,7 +1,7 @@
 use aide::{
     axum::{
         routing::{get_with, post_with, put_with},
-        ApiRouter, IntoApiResponse,
+        ApiRouter, ApiRouterService, IntoApiResponse,
     },
     transform::TransformOperation,
 };
@@ -18,8 +18,8 @@ use crate::{extractors::Json, state::AppState};
 
 use super::TodoItem;
 
-pub fn todo_routes(state: AppState) -> ApiRouter<AppState> {
-    ApiRouter::with_state(state)
+pub fn todo_routes(state: AppState) -> ApiRouterService {
+    ApiRouter::new()
         .api_route(
             "/",
             post_with(create_todo, create_todo_docs).get_with(list_todos, list_todos_docs),
@@ -29,6 +29,7 @@ pub fn todo_routes(state: AppState) -> ApiRouter<AppState> {
             get_with(get_todo, get_todo_docs).delete_with(delete_todo, delete_todo_docs),
         )
         .api_route("/:id/complete", put_with(complete_todo, complete_todo_docs))
+        .with_state(state)
 }
 
 /// New Todo details.


### PR DESCRIPTION
BREAKING CHANGE: Require using `nest_api_service` instead of `nest_service` or `nest` to propagate the API documentation. Also propagate changes to `with_state` from axum 0.6.0-rc.5.

Latest axum release candidate introduced some breaking changes. Since 0.6.0 is around the corner I have marked this version of aide as a release candidate too. I personally just wanted to be able to follow with the release candidates in my project. 