### PR TITLE
Match more closely axum's API for MethodRouter

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["tamasfe"]
 edition = "2021"
 keywords = ["generate", "api", "openapi", "documentation", "specification"]
@@ -36,11 +36,7 @@ axum-ws = ["axum/ws"]
 axum-multipart = ["axum/multipart"]
 axum-extra = ["axum", "dep:axum-extra"]
 axum-extra-cookie = ["axum", "axum-extra", "axum-extra/cookie"]
-axum-extra-cookie-private = [
-    "axum",
-    "axum-extra",
-    "axum-extra/cookie-private",
-]
+axum-extra-cookie-private = ["axum", "axum-extra", "axum-extra/cookie-private"]
 axum-extra-form = ["axum", "axum-extra", "axum-extra/form"]
 axum-extra-query = ["axum", "axum-extra", "axum-extra/query"]
 

--- a/crates/aide/src/axum/routing.rs
+++ b/crates/aide/src/axum/routing.rs
@@ -51,21 +51,6 @@ impl<S, B, E> From<MethodRouter<S, B, E>> for ApiMethodRouter<S, B, E> {
     }
 }
 
-impl<S, B, E> ApiMethodRouter<S, B, E>
-where
-    B: HttpBody + 'static,
-    B: Send,
-    S: Clone,
-{
-    /// Create a new, clean [`ApiMethodRouter`] based on [`MethodRouter::new()`](axum::routing::MethodRouter).
-    pub fn new() -> Self {
-        Self {
-            operations: IndexMap::default(),
-            router: MethodRouter::<S, B, E>::new(),
-        }
-    }
-}
-
 impl<S, B, E> ApiMethodRouter<S, B, E> {
     pub(crate) fn take_path_item(&mut self) -> PathItem {
         let mut path = PathItem::default();
@@ -312,6 +297,28 @@ where
         ApiMethodRouter {
             router: self.router.layer(layer),
             operations: self.operations,
+        }
+    }
+}
+
+impl<S, B, E> ApiMethodRouter<S, B, E>
+where
+    B: HttpBody + Send + 'static,
+    S: Clone,
+{
+    /// Create a new, clean [`ApiMethodRouter`] based on [`MethodRouter::new()`](axum::routing::MethodRouter).
+    pub fn new() -> Self {
+        Self {
+            operations: IndexMap::default(),
+            router: MethodRouter::<S, B, E>::new(),
+        }
+    }
+    /// See [axum::routing::MethodRouter] and [axum::extract::State] for more information.
+    pub fn with_state<S2>(self, state: S) -> ApiMethodRouter<S2, B, E> {
+        let router = self.router.with_state(state);
+        ApiMethodRouter::<S2, B, E> {
+            operations: self.operations,
+            router,
         }
     }
 }


### PR DESCRIPTION
I have noticed some differences between aide's `ApiMethodRouter` and axum's `MethodRouter` which made composing services from several routers (created in different scopes) frustrating. AFAIK the changes I have made are all additive and non-breaking.  This is related to axum 0.6 release which made routers carry state in their types. 