### PR TITLE
feat: expose serde errors with same format as jsonschema validation

### DIFF
--- a/crates/axum-jsonschema/Cargo.toml
+++ b/crates/axum-jsonschema/Cargo.toml
@@ -17,8 +17,10 @@ async-trait = "0.1.57"
 axum = { version = "0.6.0", default-features = false, features = ["json"] }
 http = "0.2.8"
 http-body = "0.4.5"
+itertools = "0.10.5"
 jsonschema = { version = "0.16.0", default-features = false }
 schemars = { version = "0.8.10", default-features = false }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
+serde_path_to_error = "0.1.8"
 tracing = "0.1.36"


### PR DESCRIPTION
Does what it says on the tin :) Closes #17

Some notes:

- jsonschema have made their types `OutputUnit` and `JSONPointer` impossible to use elsewhere and so I have had to make a copy. With this, the objects have `snake_case` keys rather than `camelCase`
- I have made sure to copy the styling from jsonschema for the serde error path so that they are similar
- I have exposed a 'type' parameter on the error for computers to better understand
- I have made sure to have at least an 'error' string on all errors for convenience
- despite `serde_path_to_error` returning a single value, I have made `serde_error` also a vec for consistency
- I pulled in itertools for convenience.  This can be replaced.

## Examples

```rust
// the input to our `create_user` handler
#[derive(Deserialize, JsonSchema)]
pub struct CreateUser {
    pub username: String,
    pub ages: Vec<NonZeroU8>,
    pub people: Vec<Name>,
}

#[derive(Deserialize, JsonSchema)]
pub struct Name {
    first: String,
    last: String,
    age: NonZeroU8,
}
```

### Serde issue

```json
{
    "ages": [
        1,
        2,
        3,
        3
    ],
    "people": [
        {
            "age": 1.0,
            "first": "Alex",
            "last": "Lyon"
        }
    ],
    "username": "Alex"
}
```

```json
{
    "error": "deserialization failed",
    "serde_error": [
        {
            "error": "invalid type: floating point `1`, expected a nonzero u8",
            "instance_location": "/people/0/age"
        }
    ],
    "type": "serde"
}
```

### Jsonschema issue

```json
{
    "ages": [
        1,
        2,
        3,
        3
    ],
    "people": [
        {
            "age": 0,
            "first": "Alex",
            "last": "Lyon"
        }
    ],
    "username": "Alex"
}
```

```json
{
    "error": "request schema validation failed",
    "schema_validation": [
        {
            "error": "0 is less than the minimum of 1.0",
            "instance_location": "/people/0/age",
            "keyword_location": "/properties/people/items/properties/age/minimum"
        }
    ],
    "type": "schema"
}
```

## Request issue

```json
{
```

```json
{
  "error": "Failed to parse the request body as JSON",
  "type": "json"
}
```