### PR TITLE
feat(aide): add skip_serializing_defaults feature

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -39,6 +39,7 @@ axum-extra-cookie = ["axum", "axum-extra", "axum-extra/cookie"]
 axum-extra-cookie-private = ["axum", "axum-extra", "axum-extra/cookie-private"]
 axum-extra-form = ["axum", "axum-extra", "axum-extra/form"]
 axum-extra-query = ["axum", "axum-extra", "axum-extra/query"]
+skip_serializing_defaults = []
 
 [dev-dependencies]
 serde = { version = "1.0.144", features = ["derive"] }


### PR DESCRIPTION
I was having troubles with the generated OpenAPI spec not passing validation (using [this tool](https://github.com/p1c2u/openapi-spec-validator)), specifically due to the `parameters.style` field being present where it's apparently not expected (in a header parameter). 
After looking through the code I found that [it is possible to disable default value serialization](https://github.com/tamasfe/aide/blob/master/crates/aide/src/openapi/parameter.rs#L174), however it is locked behind a feature that is impossible to enable since it isn't specified in `Cargo.toml`.

This PR simply defines the feature in `Cargo.toml` so that users can enable it.