### PR TITLE
fix(aide): fix typo in response_range() method

### DIFF
--- a/crates/aide/src/transform.rs
+++ b/crates/aide/src/transform.rs
@@ -677,7 +677,7 @@ impl<'t> TransformOperation<'t> {
                 let responses = self.operation.responses.as_mut().unwrap();
                 if responses
                     .responses
-                    .insert(StatusCode::Code(N), ReferenceOr::Item(res))
+                    .insert(StatusCode::Range(N), ReferenceOr::Item(res))
                     .is_some()
                 {
                     ctx.error(Error::ResponseExists(StatusCode::Range(N)));


### PR DESCRIPTION
Fix typo in `aide::transform::TransformOperation::response_range()` method.