### PR TITLE
fix(example-axum): fix response code typo in the example

### DIFF
--- a/examples/example-axum/src/todos/routes.rs
+++ b/examples/example-axum/src/todos/routes.rs
@@ -65,7 +65,7 @@ async fn create_todo(
 
 fn create_todo_docs(op: TransformOperation) -> TransformOperation {
     op.description("Create a new incomplete Todo item.")
-        .response::<204, Json<TodoCreated>>()
+        .response::<201, Json<TodoCreated>>()
 }
 
 #[derive(Serialize, JsonSchema)]


### PR DESCRIPTION
Fix response code in the example.
Note: with https://github.com/hyperium/http/pull/591, `http::StatusCode::as_u16()` will be directly usable for the generic parameter.