### PR TITLE
Implement `merge` on `ApiMethodRouter`

### DIFF
--- a/crates/aide/src/axum/routing.rs
+++ b/crates/aide/src/axum/routing.rs
@@ -321,6 +321,17 @@ where
             router,
         }
     }
+
+    /// See [`axum::routing::MethodRouter::merge`] for more information.
+    pub fn merge<M>(mut self, other: M) -> Self
+    where
+        M: Into<ApiMethodRouter<S, B, E>>
+    {
+        let other = other.into();
+        self.operations.extend(other.operations);
+        self.router = self.router.merge(other.router);
+        self
+    }
 }
 
 impl<S, B, E> Default for ApiMethodRouter<S, B, E>


### PR DESCRIPTION
While looking for a fix for #51 I realized that the more appropriate fix in my situation is to merge on the `MethodRouter` level. However, this is missing on aide's `ApiMethodRouter` currently so this PR adds that.