### PR TITLE
updated axum-extra and added output for cookie jars

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -22,7 +22,7 @@ bytes = { version = "1", optional = true }
 http = { version = "0.2", optional = true }
 
 axum = { version = "0.6.0", optional = true }
-axum-extra = { version = "0.4.0", optional = true }
+axum-extra = { version = "0.7.3", optional = true }
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 serde_qs = { version = "0.11.0", optional = true }

--- a/crates/aide/src/axum/outputs.rs
+++ b/crates/aide/src/axum/outputs.rs
@@ -199,3 +199,20 @@ impl OperationOutput for FormRejection {
 fn rejection_response(status_code: StatusCode, response: &Response) -> (Option<u16>, Response) {
     (Some(status_code.as_u16()), response.clone())
 }
+
+
+#[cfg(feature = "axum-extra")]
+#[allow(unused_imports)]
+mod extra {
+    use axum_extra::extract;
+
+    use super::*;
+    use crate::operation::OperationOutput;
+
+
+    #[cfg(feature = "axum-extra-cookie")]
+    impl OperationOutput for extract::CookieJar { type Inner = (); }
+
+    #[cfg(feature = "axum-extra-cookie-private")]
+    impl OperationOutput for extract::PrivateCookieJar { type Inner = (); }
+}


### PR DESCRIPTION
- updated axum-extra to 0.7.3
- added OperationOutput to cookie jar so it can be modified properly, as changes must be returned from the response.