### PR TITLE
Pull up jwt-authorizer to 0.9

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -28,7 +28,7 @@ cfg-if = "1.0.0"
 
 # custom axum extractors
 serde_qs = { version = "0.11.0", optional = true }
-jwt-authorizer = { version = "0.7.0", optional = true }
+jwt-authorizer = { version = "0.9", optional = true }
 
 [features]
 macros = ["dep:aide-macros"]


### PR DESCRIPTION
Should be quite straightforward - current version of `jwt-authorizer` is 0.9