### PR TITLE
Pull up jwt-authorizer to 0.10

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -29,7 +29,7 @@ cfg-if = "1.0.0"
 
 # custom axum extractors
 serde_qs = { version = "0.12.0", optional = true }
-jwt-authorizer = { version = "0.9", optional = true }
+jwt-authorizer = { version = "0.10", default-features = false, optional = true }
 axum-sqlx-tx = { version = "0.5", optional = true }
 sqlx = { version = "0.6", optional = true }
 


### PR DESCRIPTION
Starting with `jwt-authorizer 0.10` one has a choice of TLS implementation to use with it. 
The `default-features = false` is set here to not affect the end user selection of which TLS implementation to use.