### PR TITLE
Fix docsrs build

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -59,4 +59,5 @@ tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
 
 [package.metadata.docs.rs]
 all-features = true
+features = ["axum-sqlx-tx/runtime-tokio-rustls"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/aide/src/redoc/mod.rs
+++ b/crates/aide/src/redoc/mod.rs
@@ -136,7 +136,7 @@ mod axum_impl {
         /// ```
         /// # use aide::axum::{ApiRouter, routing::get};
         /// # use aide::redoc::Redoc;
-        /// ApiRouter::new()
+        /// ApiRouter::<()>::new()
         ///     .route("/docs", Redoc::new("/openapi.json").axum_route());
         /// ```
         pub fn axum_route<S>(&self) -> ApiMethodRouter<S>


### PR DESCRIPTION
It would normally be set by the project containing aide as a dependency with axum-sqlx-tx, but in the docs build it wasn't set. So eventually the 'sqlx-rt' crate complained that it missed a feature.

Also fixing calling `cargo test --all` by adding a generic parameter to `ApiRouter::new()` call.