### PR TITLE
feat(crate): aide-axum-sqlx-tx

### DIFF
--- a/crates/aide-axum-sqlx-tx/Cargo.toml
+++ b/crates/aide-axum-sqlx-tx/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "aide-axum-sqlx-tx"
+version = "0.11.0"
+edition = "2021"
+resolver = "2"
+
+[dependencies]
+sqlx-06 = { package = "axum-sqlx-tx", version = "0.5.0", optional = true }
+sqlx-07 = { package = "axum-sqlx-tx", version = "0.6.0", optional = true }
+aide = { version = "0.11.0", path = "../aide" }
+
+[dev-dependencies]
+sqlx = { version = "0.7", features = ["macros", "postgres"] }
+
+[package.metadata.docs.rs]
+features = ["sqlx-07", "postgres"]
+
+[features]
+default = ["sqlx-07"]
+sqlx-07 = ["dep:sqlx-07"]
+sqlx-06 = ["dep:sqlx-06"]
+
+any = ["sqlx-07?/any", "sqlx-06?/any"]
+mysql = ["sqlx-07?/mysql", "sqlx-06?/mysql"]
+postgres = ["sqlx-07?/postgres", "sqlx-06?/postgres"]
+
+runtime-tokio-native-tls = ["sqlx-07?/runtime-tokio-native-tls", "sqlx-06?/runtime-tokio-native-tls"]
+runtime-tokio-rustls = ["sqlx-07?/runtime-tokio-rustls", "sqlx-06?/runtime-tokio-rustls"]

--- a/crates/aide-axum-sqlx-tx/src/lib.rs
+++ b/crates/aide-axum-sqlx-tx/src/lib.rs
@@ -1,0 +1,51 @@
+//! # Aide Axum Sqlx Tx
+//!
+//! Aide Axum Salx Tx is a re-export of the crate axum-sqlx-tx to be used in aide requests  
+//!
+//!
+//! ## Features
+//! - `default` or `sqlx-07`: uses `axum-sqlx-tx:0.6.0` and is compatible with `sqlx:0.7`
+//! - `sqlx-06`: overrides default sqlx-07 and uses `axum-sqlx-tx:0.5.0` and is compatible with `sqlx:0.6`
+//!
+#![cfg_attr(
+    all(feature = "sqlx-07", feature = "postgres"),
+    doc = r##"
+## Example
+
+```
+# use aide_axum_sqlx_tx::Tx;
+# use sqlx::{Postgres, query};
+
+async fn get_hello_world(
+     mut tx: Tx<Postgres>,
+ ) -> Result<String, String> {
+    let (res,): (String,) = sqlx::query_as("select 'hello world'")
+    .fetch_one(&mut *tx) // deref mut
+    .await.map_err(|err|err.to_string())?;
+    Ok(res)
+ }
+```
+"##
+)]
+
+#[cfg(all(feature = "sqlx-07", feature = "sqlx-06"))]
+compile_error!(
+    "aide-axum-sqlx-tx features \"sqlx-07\" and \"sqlx-06\" cannot be enabled at the same time"
+);
+
+#[cfg(all(not(feature = "sqlx-07"), not(feature = "sqlx-06")))]
+compile_error!("aide-axum-sqlx-tx feature \"sqlx-07\" or \"sqlx-06\" must be enabled");
+
+use aide::NoApi;
+
+#[cfg(feature = "sqlx-06")]
+use sqlx_06 as tx;
+#[cfg(all(feature = "sqlx-07", not(feature = "sqlx-06")))]
+use sqlx_07 as tx;
+
+#[cfg(any(feature = "sqlx-07", feature = "sqlx-06"))]
+#[doc(inline)]
+pub use tx::{Error, Layer, Service};
+
+#[cfg(any(feature = "sqlx-07", feature = "sqlx-06"))]
+pub type Tx<T> = NoApi<tx::Tx<T>>;


### PR DESCRIPTION
- implemented drop in replacement axum-sqlx-tx in a separate crate using new `NoApi` struct
- aded feature flags for selecting relevant version and features
- sqlite was left out due to conflicts.