### PR TITLE
Axum 0.7 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["crates/*", "examples/*"]
+resolver = "2"

--- a/crates/aide-axum-sqlx-tx/Cargo.toml
+++ b/crates/aide-axum-sqlx-tx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide-axum-sqlx-tx"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 resolver = "2"
 authors = ["Wicpar"]
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 sqlx-06 = { package = "axum-sqlx-tx", version = "0.5.0", optional = true }
 sqlx-07 = { package = "axum-sqlx-tx", version = "0.6.0", optional = true }
-aide = { version = "0.12.0", path = "../aide" }
+aide = { version = "0.13.0", path = "../aide" }
 
 [dev-dependencies]
 sqlx = { version = "^0.7", features = ["postgres"] }

--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["tamasfe"]
 edition = "2021"
 keywords = ["generate", "api", "openapi", "documentation", "specification"]
@@ -10,8 +10,8 @@ description = "A code-first API documentation library"
 readme = "README.md"
 
 [dependencies]
-indexmap = { version = "1", features = ["serde"] }
-schemars = { version = "0.8", features = ["impl_json_schema", "indexmap"] }
+indexmap = { version = "2.1", features = ["serde"] }
+schemars = { version = "0.8.16", features = ["impl_json_schema", "indexmap2"] }
 serde = "1"
 serde_json = "1"
 thiserror = "1"
@@ -20,10 +20,10 @@ aide-macros = { version = "0.7.0", path = "../aide-macros", optional = true }
 derive_more = "0.99.17"
 
 bytes = { version = "1", optional = true }
-http = { version = "0.2", optional = true }
+http = { version = "1.0.0", optional = true }
 
-axum = { version = "0.6.0", optional = true }
-axum-extra = { version = "0.7.3", optional = true }
+axum = { version = "0.7.1", optional = true }
+axum-extra = { version = "0.9.0", optional = true }
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 cfg-if = "1.0.0"
@@ -31,7 +31,7 @@ cfg-if = "1.0.0"
 
 # custom axum extractors
 serde_qs = { version = "0.12.0", optional = true }
-jwt-authorizer = { version = "0.10", default-features = false, optional = true }
+jwt-authorizer = { version = "0.13", default-features = false, optional = true }
 
 [features]
 macros = ["dep:aide-macros"]
@@ -39,7 +39,7 @@ redoc = []
 skip_serializing_defaults = []
 
 axum = ["dep:axum", "bytes", "http", "dep:tower-layer", "dep:tower-service", "serde_qs?/axum"]
-axum-headers = ["axum/headers"]
+# axum-headers = ["axum/headers"]
 axum-ws = ["axum/ws"]
 axum-multipart = ["axum/multipart"]
 axum-extra = ["axum", "dep:axum-extra"]

--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -6,9 +6,12 @@ use crate::{
     },
     operation::{add_parameters, set_body},
 };
-use axum::extract::{
-    BodyStream, ConnectInfo, Extension, Form, Host, Json, MatchedPath, OriginalUri, Path, Query,
-    RawBody, RawQuery, State,
+use axum::{
+    body::Body,
+    extract::{
+        ConnectInfo, Extension, Form, Host, Json, MatchedPath, OriginalUri, Path, Query, RawQuery,
+        State,
+    },
 };
 use indexmap::IndexMap;
 use schemars::{
@@ -24,11 +27,10 @@ use crate::{
 
 impl<T> OperationInput for Extension<T> {}
 impl<T> OperationInput for State<T> {}
-impl OperationInput for BodyStream {}
 impl<T> OperationInput for ConnectInfo<T> {}
 impl OperationInput for MatchedPath {}
 impl OperationInput for OriginalUri {}
-impl OperationInput for RawBody {}
+impl OperationInput for Body {}
 impl OperationInput for RawQuery {}
 impl OperationInput for Host {}
 

--- a/crates/aide/src/gen.rs
+++ b/crates/aide/src/gen.rs
@@ -42,13 +42,10 @@ pub fn on_error(handler: impl Fn(Error) + 'static) {
 /// Collect common schemas in the thread-local context,
 /// then store them under `#/components/schemas` the next
 /// time generated content is merged into [`OpenApi`].
-/// This feature is disabled by default.
+/// This feature is enabled by default.
 ///
 /// This will automatically clear the schemas stored
 /// in the context when they are merged into the documentation.
-///
-/// **warning**: This might cause name conflicts that are not detected!
-/// For more information see <https://github.com/GREsau/schemars/issues/62>.
 ///
 /// [`OpenApi`]: crate::openapi::OpenApi
 pub fn extract_schemas(extract: bool) {
@@ -83,15 +80,17 @@ pub fn inferred_empty_response_status(status: u16) {
 /// Infer responses based on request handler
 /// return types.
 ///
-/// This is disabled by default to avoid incorrect
-/// documentation.
+/// This is enabled by default.
 pub fn infer_responses(infer: bool) {
     in_context(|ctx| {
         ctx.infer_responses = infer;
     });
 }
 
-/// Output All error responses based on axum.
+/// Output all theoretically possbile error responses
+/// including framework-specific ones.
+///
+/// This is disabled by default.
 pub fn all_error_responses(infer: bool) {
     in_context(|ctx| {
         ctx.all_error_responses = infer;
@@ -146,11 +145,11 @@ impl GenContext {
 
         Self {
             schema: SchemaGenerator::new(
-                SchemaSettings::draft07().with(|s| s.inline_subschemas = true),
+                SchemaSettings::draft07().with(|s| s.inline_subschemas = false),
             ),
-            infer_responses: false,
+            infer_responses: true,
             all_error_responses: false,
-            extract_schemas: false,
+            extract_schemas: true,
             show_error: default_error_filter,
             error_handler: None,
             no_content_status,

--- a/crates/aide/src/helpers/no_api.rs
+++ b/crates/aide/src/helpers/no_api.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{OperationInput, OperationOutput};
 
-/// Allows non [OperationInput] or [OperationOutput] types to be used in aide handlers with a default empty documentation.  
-/// For types that already implement [OperationInput] or [OperationOutput] it overrides the documentation and hides it.
+/// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a default empty documentation.  
+/// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation and hides it.
 /// ```ignore
 /// pub async fn my_sqlx_tx_endpoint(
 ///     NoApi(mut tx): NoApi<Tx<sqlx::Any>> // allows usage of the TX
@@ -45,9 +45,9 @@ impl<T> OperationOutput for NoApi<T> {
 
 #[cfg(feature = "axum")]
 mod axum {
-    use axum::async_trait;
     use axum::extract::{FromRequest, FromRequestParts};
     use axum::response::{IntoResponse, IntoResponseParts, Response, ResponseParts};
+    use axum::{async_trait, body::Body};
     use http::request::Parts;
     use http::Request;
 
@@ -87,15 +87,14 @@ mod axum {
     }
 
     #[async_trait]
-    impl<T, S, B> FromRequest<S, B> for NoApi<T>
+    impl<T, S> FromRequest<S> for NoApi<T>
     where
-        T: FromRequest<S, B>,
+        T: FromRequest<S>,
         S: Send + Sync,
-        B: Send + 'static,
     {
         type Rejection = <T>::Rejection;
 
-        async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+        async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
             Ok(Self(<T>::from_request(req, state).await?))
         }
     }

--- a/crates/aide/src/redoc/mod.rs
+++ b/crates/aide/src/redoc/mod.rs
@@ -52,18 +52,20 @@
 //!         },
 //!         ..OpenApi::default()
 //!     };
+//! 
+//!     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
 //!
-//!     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
-//!         .serve(
-//!             app
-//!                 // Generate the documentation.
-//!                 .finish_api(&mut api)
-//!                 // Expose the documentation to the handlers.
-//!                 .layer(Extension(api))
-//!                 .into_make_service(),
-//!         )
-//!         .await
-//!         .unwrap();
+//!     axum::serve(
+//!         listener,
+//!         app
+//!             // Generate the documentation.
+//!             .finish_api(&mut api)
+//!             // Expose the documentation to the handlers.
+//!             .layer(Extension(api))
+//!             .into_make_service(),
+//!     )
+//!     .await
+//!     .unwrap();
 //! }
 //! ```
 
@@ -162,12 +164,9 @@ mod axum_impl {
         /// );
         /// ```
         #[must_use]
-        pub fn axum_handler<S, B>(
+        pub fn axum_handler<S>(
             &self,
-        ) -> impl AxumOperationHandler<(), Html<&'static str>, ((),), S, B>
-        where
-            B: axum::body::HttpBody + Send + 'static,
-        {
+        ) -> impl AxumOperationHandler<(), Html<&'static str>, ((),), S> {
             let html = self.html();
             // This string will be used during the entire lifetime of the program
             // so it's safe to leak it

--- a/crates/axum-jsonschema/Cargo.toml
+++ b/crates/axum-jsonschema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-jsonschema"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["tamasfe"]
 keywords = ["web", "axum", "json"]
@@ -10,14 +10,14 @@ description = "Request JSON schema validation for axum"
 readme = "README.md"
 
 [dependencies]
-aide = { version = "0.12.0", path = "../aide", optional = true, features = [
+aide = { version = "0.13.0", path = "../aide", optional = true, features = [
     "axum",
 ] }
 async-trait = "0.1.57"
-axum = { version = "0.6.0", default-features = false, features = ["json"] }
-http = "0.2.8"
-http-body = "0.4.5"
-itertools = "0.10.5"
+axum = { version = "0.7.1", default-features = false, features = ["json"] }
+http = "1.0.0"
+http-body = "1.0.0"
+itertools = "0.12.0"
 jsonschema = { version = "0.17.0", default-features = false }
 schemars = { version = "0.8.10", default-features = false }
 serde = { version = "1.0.144", features = ["derive"] }

--- a/examples/example-axum/Cargo.toml
+++ b/examples/example-axum/Cargo.toml
@@ -12,12 +12,12 @@ aide = { path = "../../crates/aide", features = [
     "macros",
 ] }
 async-trait = "0.1.57"
-axum = { version = "0.6.0", features = ["macros"] }
-axum-extra = "0.7.4"
+axum = { version = "0.7.1", features = ["macros"] }
+axum-extra = "0.9.0"
 axum-jsonschema = { path = "../../crates/axum-jsonschema", features = [
     "aide",
 ] }
-axum-macros = "0.3.0"
+axum-macros = "0.4.0"
 schemars = { version = "0.8.10", features = ["uuid1"] }
 serde = { version = "1.0.144", features = ["derive", "rc"] }
 serde_json = "1.0.85"

--- a/examples/example-axum/src/main.rs
+++ b/examples/example-axum/src/main.rs
@@ -11,6 +11,7 @@ use errors::AppError;
 use extractors::Json;
 use state::AppState;
 use todos::routes::todo_routes;
+use tokio::net::TcpListener;
 use uuid::Uuid;
 
 pub mod docs;
@@ -40,10 +41,9 @@ async fn main() {
 
     println!("Example docs are accessible at http://127.0.0.1:3000/docs");
 
-    axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+
+    axum::serve(listener, app).await.unwrap();
 }
 
 fn api_docs(api: TransformOpenApi) -> TransformOpenApi {


### PR DESCRIPTION
Closes #87, closes #82.

I also fixed the inconsistencies between the router's `<op>` and `<op>_with` functions so that the former only calls the latter with a no-op closure, thus they cannot get out of sync.

I also changed the document generation defaults:

- Responses are now inferred by default, as this seems to be the most common use-case, and the route functions will respect the global setting (this was a bug before).
- Schema inlining is disabled by default, because schema collisions are fixed in https://github.com/GREsau/schemars/pull/247.