### PR TITLE
definitions_path fix

### DIFF
--- a/crates/aide/src/gen.rs
+++ b/crates/aide/src/gen.rs
@@ -59,6 +59,7 @@ pub fn extract_schemas(extract: bool) {
         } else {
             ctx.schema = SchemaGenerator::new(SchemaSettings::draft07().with(|s| {
                 s.inline_subschemas = true;
+                s.definitions_path = "#/components/schemas/".into();
             }));
             ctx.extract_schemas = false;
         }
@@ -144,9 +145,10 @@ impl GenContext {
         }
 
         Self {
-            schema: SchemaGenerator::new(
-                SchemaSettings::draft07().with(|s| s.inline_subschemas = false),
-            ),
+            schema: SchemaGenerator::new(SchemaSettings::draft07().with(|s| {
+                s.inline_subschemas = false;
+                s.definitions_path = "#/components/schemas/".into();
+            })),
             infer_responses: true,
             all_error_responses: false,
             extract_schemas: true,


### PR DESCRIPTION
Hi!
I got my OpenApi generator broken after updating to 0.13.0.
It generates a 'components/schemas' section for custom schemas but anchors to them are wrong.
For example (I translated JSON to YAML for clarity):
``` yaml
paths:
  /healthz:
    get:
      responses:
        '200':
          description: ''
          content:
            application/json:
              schema:
                $ref: '#/definitions/HealthCheckResult'
```
I don't know if my fix is a correct one but it did fix the issue for me.