### PR TITLE
Feat extra extractors

### DIFF
--- a/crates/axum-jsonschema/src/extract/form.rs
+++ b/crates/axum-jsonschema/src/extract/form.rs
@@ -1,0 +1,135 @@
+use std::any::{type_name, TypeId};
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    extract::{FromRequest, Request},
+    response::IntoResponse,
+};
+use jsonschema::{output::BasicOutput, JSONSchema};
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+
+use crate::CONTEXT;
+
+use super::SerdeSchemaRejection;
+
+/// Wrapper type over [`axum::Form`] that validates
+/// requests and responds with a more helpful validation
+/// message.
+pub struct Form<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequest<S> for Form<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned + JsonSchema + 'static,
+{
+    type Rejection = FormRejection;
+
+    /// Perform the extraction.
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
+        let value: Value = match axum::Form::from_request(req, state).await {
+            Ok(j) => j.0,
+            Err(error) => {
+                return Err(FormRejection::Form(error));
+            }
+        };
+
+        let validation_result = CONTEXT.with(|ctx| {
+            let ctx = &mut *ctx.borrow_mut();
+            let schema = ctx.schemas.entry(TypeId::of::<T>()).or_insert_with(|| {
+                match jsonschema::JSONSchema::compile(
+                    &serde_json::to_value(ctx.generator.root_schema_for::<T>()).unwrap(),
+                ) {
+                    Ok(s) => s,
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            type_name = type_name::<T>(),
+                            "invalid JSON schema for type"
+                        );
+                        JSONSchema::compile(&Value::Object(Map::default())).unwrap()
+                    }
+                }
+            });
+
+            let out = schema.apply(&value).basic();
+
+            match out {
+                BasicOutput::Valid(_) => Ok(()),
+                BasicOutput::Invalid(v) => Err(v),
+            }
+        });
+
+        if let Err(errors) = validation_result {
+            return Err(FormRejection::SerdeSchema(SerdeSchemaRejection::Schema(
+                errors,
+            )));
+        }
+
+        match serde_path_to_error::deserialize(value) {
+            Ok(v) => Ok(Form(v)),
+            Err(error) => Err(FormRejection::SerdeSchema(SerdeSchemaRejection::Serde(
+                error,
+            ))),
+        }
+    }
+}
+
+/// Rejection for [`Form`].
+#[derive(Debug)]
+pub enum FormRejection {
+    /// A rejection returned by [`axum::Form`].
+    Form(axum::extract::rejection::FormRejection),
+    /// A serde or schema-validation error.
+    SerdeSchema(SerdeSchemaRejection),
+}
+
+impl IntoResponse for FormRejection {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::Form(e) => e.into_response(),
+            Self::SerdeSchema(e) => e.into_response(),
+        }
+    }
+}
+
+#[cfg(feature = "aide")]
+mod impl_aide {
+    use super::*;
+
+    impl<T> aide::OperationInput for Form<T>
+    where
+        T: JsonSchema,
+    {
+        fn operation_input(
+            ctx: &mut aide::gen::GenContext,
+            operation: &mut aide::openapi::Operation,
+        ) {
+            axum::Form::<T>::operation_input(ctx, operation);
+        }
+    }
+
+    impl<T> aide::OperationOutput for Form<T>
+    where
+        T: JsonSchema,
+    {
+        type Inner = <axum::Form<T> as aide::OperationOutput>::Inner;
+
+        fn operation_response(
+            ctx: &mut aide::gen::GenContext,
+            op: &mut aide::openapi::Operation,
+        ) -> Option<aide::openapi::Response> {
+            axum::Form::<T>::operation_response(ctx, op)
+        }
+
+        fn inferred_responses(
+            ctx: &mut aide::gen::GenContext,
+            operation: &mut aide::openapi::Operation,
+        ) -> Vec<(Option<u16>, aide::openapi::Response)> {
+            axum::Form::<T>::inferred_responses(ctx, operation)
+        }
+    }
+}

--- a/crates/axum-jsonschema/src/extract/mod.rs
+++ b/crates/axum-jsonschema/src/extract/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod path;

--- a/crates/axum-jsonschema/src/extract/mod.rs
+++ b/crates/axum-jsonschema/src/extract/mod.rs
@@ -1,7 +1,9 @@
+mod form;
 mod json;
 mod path;
 mod query;
 
+pub use form::*;
 pub use json::*;
 pub use path::*;
 pub use query::*;

--- a/crates/axum-jsonschema/src/extract/mod.rs
+++ b/crates/axum-jsonschema/src/extract/mod.rs
@@ -1,1 +1,102 @@
-pub(crate) mod path;
+mod json;
+mod path;
+
+pub use json::*;
+pub use path::*;
+
+use std::collections::VecDeque;
+
+use axum::response::IntoResponse;
+use http::StatusCode;
+use itertools::Itertools;
+use jsonschema::output::{ErrorDescription, OutputUnit};
+use serde::Serialize;
+use serde_path_to_error::Segment;
+
+/// Common Rejection.
+#[derive(Debug)]
+pub enum SerdeSchemaRejection {
+    /// A serde error.
+    Serde(serde_path_to_error::Error<serde_json::Error>),
+    /// A schema validation error.
+    Schema(VecDeque<OutputUnit<ErrorDescription>>),
+}
+
+/// The response that is returned by default.
+#[derive(Debug, Serialize)]
+struct JsonSchemaErrorResponse {
+    error: String,
+    #[serde(flatten)]
+    extra: AdditionalError,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AdditionalError {
+    Deserialization(DeserializationResponse),
+    Schema(SchemaResponse),
+}
+
+#[derive(Debug, Serialize)]
+struct DeserializationResponse {
+    deserialization_error: VecDeque<PathError>,
+}
+
+#[derive(Debug, Serialize)]
+struct SchemaResponse {
+    schema_validation: VecDeque<PathError>,
+}
+
+#[derive(Debug, Serialize)]
+struct PathError {
+    instance_location: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    keyword_location: Option<String>,
+    error: String,
+}
+
+impl From<SerdeSchemaRejection> for JsonSchemaErrorResponse {
+    fn from(rejection: SerdeSchemaRejection) -> Self {
+        match rejection {
+            SerdeSchemaRejection::Serde(s) => Self {
+                error: "deserialization failed".to_string(),
+                extra: AdditionalError::Deserialization(DeserializationResponse {
+                    deserialization_error: VecDeque::from([PathError {
+                        // keys and index seperated by a '/'
+                        // enum is ignored because it doesn't exist in json
+                        instance_location: std::iter::once(String::new())
+                            .chain(s.path().iter().map(|s| match s {
+                                Segment::Map { key } => key.to_string(),
+                                Segment::Seq { index } => index.to_string(),
+                                _ => "?".to_string(),
+                            }))
+                            .join("/"),
+                        keyword_location: None,
+                        error: s.into_inner().to_string(),
+                    }]),
+                }),
+            },
+            SerdeSchemaRejection::Schema(s) => Self {
+                error: "request schema validation failed".to_string(),
+                extra: AdditionalError::Schema(SchemaResponse {
+                    schema_validation: s
+                        .into_iter()
+                        .map(|v| PathError {
+                            instance_location: v.instance_location().to_string(),
+                            keyword_location: Some(v.keyword_location().to_string()),
+                            error: v.error_description().to_string(),
+                        })
+                        .collect(),
+                }),
+            },
+        }
+    }
+}
+
+impl IntoResponse for SerdeSchemaRejection {
+    fn into_response(self) -> axum::response::Response {
+        let mut res = axum::Json(JsonSchemaErrorResponse::from(self)).into_response();
+        *res.status_mut() = StatusCode::BAD_REQUEST;
+        res
+    }
+}

--- a/crates/axum-jsonschema/src/extract/mod.rs
+++ b/crates/axum-jsonschema/src/extract/mod.rs
@@ -1,8 +1,10 @@
 mod json;
 mod path;
+mod query;
 
 pub use json::*;
 pub use path::*;
+pub use query::*;
 
 use std::collections::VecDeque;
 

--- a/crates/axum-jsonschema/src/extract/path.rs
+++ b/crates/axum-jsonschema/src/extract/path.rs
@@ -1,0 +1,92 @@
+use std::any::{type_name, TypeId};
+
+use async_trait::async_trait;
+use axum::extract::FromRequestParts;
+use http::request::Parts;
+use jsonschema::{output::BasicOutput, JSONSchema};
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+
+use crate::{JsonSchemaRejection, CONTEXT};
+
+/// Type emulate [`axum::extract::Path`] that validates
+/// requests with a more helpful validation
+/// message.
+pub struct Path<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for Path<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned + JsonSchema + 'static,
+{
+    type Rejection = JsonSchemaRejection;
+
+    /// Perform the extraction.
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let raw_parrams = match axum::extract::RawPathParams::from_request_parts(parts, state).await
+        {
+            Ok(p) => p,
+            Err(e) => return Err(JsonSchemaRejection::Path(e)),
+        };
+        let value = Value::Object(
+            raw_parrams
+                .into_iter()
+                .map(|p| (p.0.to_owned(), Value::String(p.1.to_owned())))
+                .collect::<Map<_, _>>(),
+        );
+
+        let validation_result = CONTEXT.with(|ctx| {
+            let ctx = &mut *ctx.borrow_mut();
+            let schema = ctx.schemas.entry(TypeId::of::<T>()).or_insert_with(|| {
+                match jsonschema::JSONSchema::compile(
+                    &serde_json::to_value(ctx.generator.root_schema_for::<T>()).unwrap(),
+                ) {
+                    Ok(s) => s,
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            type_name = type_name::<T>(),
+                            "invalid JSON schema for type"
+                        );
+                        JSONSchema::compile(&Value::Object(Map::default())).unwrap()
+                    }
+                }
+            });
+
+            let out = schema.apply(&value).basic();
+
+            match out {
+                BasicOutput::Valid(_) => Ok(()),
+                BasicOutput::Invalid(v) => Err(v),
+            }
+        });
+
+        if let Err(errors) = validation_result {
+            return Err(JsonSchemaRejection::Schema(errors));
+        }
+
+        match serde_path_to_error::deserialize(value) {
+            Ok(v) => Ok(Path(v)),
+            Err(error) => Err(JsonSchemaRejection::Serde(error)),
+        }
+    }
+}
+
+#[cfg(feature = "aide")]
+mod impl_aide {
+    use super::*;
+
+    impl<T> aide::OperationInput for Path<T>
+    where
+        T: JsonSchema,
+    {
+        fn operation_input(
+            ctx: &mut aide::gen::GenContext,
+            operation: &mut aide::openapi::Operation,
+        ) {
+            axum::extract::Path::<T>::operation_input(ctx, operation);
+        }
+    }
+}

--- a/crates/axum-jsonschema/src/extract/query.rs
+++ b/crates/axum-jsonschema/src/extract/query.rs
@@ -73,7 +73,7 @@ where
     }
 }
 
-/// Rejection for [`Path`].
+/// Rejection for [`Query`].
 #[derive(Debug)]
 pub enum QueryRejection {
     /// A rejection returned by [`axum::extract::Query`].

--- a/crates/axum-jsonschema/src/extract/query.rs
+++ b/crates/axum-jsonschema/src/extract/query.rs
@@ -12,8 +12,8 @@ use crate::CONTEXT;
 
 use super::SerdeSchemaRejection;
 
-/// Extractor with similar behaviour to [`axum::extract::Query`]
-/// but it validates requests with a more helpful validation
+/// Wrapper type over [`axum::extract::Query`] that validates
+/// requests and responds with a more helpful validation
 /// message.
 pub struct Query<T>(pub T);
 

--- a/crates/axum-jsonschema/src/extract/query.rs
+++ b/crates/axum-jsonschema/src/extract/query.rs
@@ -1,0 +1,109 @@
+use std::any::{type_name, TypeId};
+
+use async_trait::async_trait;
+use axum::{extract::FromRequestParts, response::IntoResponse};
+use http::request::Parts;
+use jsonschema::{output::BasicOutput, JSONSchema};
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Value};
+
+use crate::CONTEXT;
+
+use super::SerdeSchemaRejection;
+
+/// Extractor with similar behaviour to [`axum::extract::Query`]
+/// but it validates requests with a more helpful validation
+/// message.
+pub struct Query<T>(pub T);
+
+#[async_trait]
+impl<S, T> FromRequestParts<S> for Query<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned + JsonSchema + 'static,
+{
+    type Rejection = QueryRejection;
+
+    /// Perform the extraction.
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let value: Value = axum::extract::Query::from_request_parts(parts, state)
+            .await
+            .map_err(|e| QueryRejection::Query(e))?
+            .0;
+
+        let validation_result = CONTEXT.with(|ctx| {
+            let ctx = &mut *ctx.borrow_mut();
+            let schema = ctx.schemas.entry(TypeId::of::<T>()).or_insert_with(|| {
+                match jsonschema::JSONSchema::compile(
+                    &serde_json::to_value(ctx.generator.root_schema_for::<T>()).unwrap(),
+                ) {
+                    Ok(s) => s,
+                    Err(error) => {
+                        tracing::error!(
+                            %error,
+                            type_name = type_name::<T>(),
+                            "invalid JSON schema for type"
+                        );
+                        JSONSchema::compile(&Value::Object(Map::default())).unwrap()
+                    }
+                }
+            });
+
+            let out = schema.apply(&value).basic();
+
+            match out {
+                BasicOutput::Valid(_) => Ok(()),
+                BasicOutput::Invalid(v) => Err(v),
+            }
+        });
+
+        if let Err(errors) = validation_result {
+            return Err(QueryRejection::SerdeSchema(SerdeSchemaRejection::Schema(
+                errors,
+            )));
+        }
+
+        match serde_path_to_error::deserialize(value) {
+            Ok(v) => Ok(Query(v)),
+            Err(error) => Err(QueryRejection::SerdeSchema(SerdeSchemaRejection::Serde(
+                error,
+            ))),
+        }
+    }
+}
+
+/// Rejection for [`Path`].
+#[derive(Debug)]
+pub enum QueryRejection {
+    /// A rejection returned by [`axum::extract::Query`].
+    Query(axum::extract::rejection::QueryRejection),
+    /// A serde or schema-validation error.
+    SerdeSchema(SerdeSchemaRejection),
+}
+
+impl IntoResponse for QueryRejection {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::Query(e) => e.into_response(),
+            Self::SerdeSchema(e) => e.into_response(),
+        }
+    }
+}
+
+#[cfg(feature = "aide")]
+mod impl_aide {
+    use super::*;
+
+    impl<T> aide::OperationInput for Query<T>
+    where
+        T: JsonSchema,
+    {
+        fn operation_input(
+            ctx: &mut aide::gen::GenContext,
+            operation: &mut aide::openapi::Operation,
+        ) {
+            axum::extract::Query::<T>::operation_input(ctx, operation);
+        }
+    }
+}

--- a/crates/axum-jsonschema/src/lib.rs
+++ b/crates/axum-jsonschema/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 //! A simple crate provides a drop-in replacement for [`axum::Json`]
-//! that uses [`jsonschema`] to validate requests schemas
-//! generated via [`schemars`].
+//! and friends in [`axum::extract`] that uses [`jsonschema`] to
+//! validate requests schemas generated via [`schemars`].
 //!
 //! You might want to do this in order to provide a better
 //! experience for your clients and not leak serde's error messages.
@@ -15,103 +15,13 @@
 
 #![warn(clippy::pedantic, missing_docs)]
 #![allow(clippy::wildcard_imports)]
-use std::{
-    any::{type_name, TypeId},
-    cell::RefCell,
-    collections::{HashMap, VecDeque},
-};
+use std::{any::TypeId, cell::RefCell, collections::HashMap};
 
-use async_trait::async_trait;
-use axum::{
-    body::Body,
-    extract::{rejection::JsonRejection, FromRequest},
-    response::IntoResponse,
-};
-use http::{Request, StatusCode};
-use itertools::Itertools;
-use jsonschema::{
-    output::{BasicOutput, ErrorDescription, OutputUnit},
-    JSONSchema,
-};
-use schemars::{
-    gen::{SchemaGenerator, SchemaSettings},
-    JsonSchema,
-};
-use serde::{de::DeserializeOwned, Serialize};
-use serde_json::{Map, Value};
-use serde_path_to_error::Segment;
+use jsonschema::JSONSchema;
+use schemars::gen::{SchemaGenerator, SchemaSettings};
 
-mod extract;
-
-pub use extract::path::Path;
-
-/// Wrapper type over [`axum::Json`] that validates
-/// requests and responds with a more helpful validation
-/// message.
-pub struct Json<T>(pub T);
-
-#[async_trait]
-impl<S, T> FromRequest<S> for Json<T>
-where
-    S: Send + Sync,
-    T: DeserializeOwned + JsonSchema + 'static,
-{
-    type Rejection = JsonSchemaRejection;
-
-    /// Perform the extraction.
-    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
-        let value: Value = match axum::Json::from_request(req, state).await {
-            Ok(j) => j.0,
-            Err(error) => {
-                return Err(JsonSchemaRejection::Json(error));
-            }
-        };
-
-        let validation_result = CONTEXT.with(|ctx| {
-            let ctx = &mut *ctx.borrow_mut();
-            let schema = ctx.schemas.entry(TypeId::of::<T>()).or_insert_with(|| {
-                match jsonschema::JSONSchema::compile(
-                    &serde_json::to_value(ctx.generator.root_schema_for::<T>()).unwrap(),
-                ) {
-                    Ok(s) => s,
-                    Err(error) => {
-                        tracing::error!(
-                            %error,
-                            type_name = type_name::<T>(),
-                            "invalid JSON schema for type"
-                        );
-                        JSONSchema::compile(&Value::Object(Map::default())).unwrap()
-                    }
-                }
-            });
-
-            let out = schema.apply(&value).basic();
-
-            match out {
-                BasicOutput::Valid(_) => Ok(()),
-                BasicOutput::Invalid(v) => Err(v),
-            }
-        });
-
-        if let Err(errors) = validation_result {
-            return Err(JsonSchemaRejection::Schema(errors));
-        }
-
-        match serde_path_to_error::deserialize(value) {
-            Ok(v) => Ok(Json(v)),
-            Err(error) => Err(JsonSchemaRejection::Serde(error)),
-        }
-    }
-}
-
-impl<T> IntoResponse for Json<T>
-where
-    T: Serialize,
-{
-    fn into_response(self) -> axum::response::Response {
-        axum::Json(self.0).into_response()
-    }
-}
+/// Extra extractors similar to [`axum::extract`].
+pub mod extract;
 
 thread_local! {
     pub(crate) static CONTEXT: RefCell<SchemaContext> = RefCell::new(SchemaContext::new());
@@ -129,146 +39,6 @@ impl SchemaContext {
                 .with(|g| g.inline_subschemas = true)
                 .into_generator(),
             schemas: HashMap::default(),
-        }
-    }
-}
-
-/// Rejection for [`Json`].
-#[derive(Debug)]
-pub enum JsonSchemaRejection {
-    /// A rejection returned by [`axum::Json`].
-    Json(JsonRejection),
-    /// A rejection returned by [`axum::extract::RawPathParams`].
-    Path(axum::extract::rejection::RawPathParamsRejection),
-    /// A serde error.
-    Serde(serde_path_to_error::Error<serde_json::Error>),
-    /// A schema validation error.
-    Schema(VecDeque<OutputUnit<ErrorDescription>>),
-}
-
-/// The response that is returned by default.
-#[derive(Debug, Serialize)]
-struct JsonSchemaErrorResponse {
-    error: String,
-    #[serde(flatten)]
-    extra: AdditionalError,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-enum AdditionalError {
-    Json,
-    Path,
-    Deserialization(DeserializationResponse),
-    Schema(SchemaResponse),
-}
-
-#[derive(Debug, Serialize)]
-struct DeserializationResponse {
-    deserialization_error: VecDeque<PathError>,
-}
-
-#[derive(Debug, Serialize)]
-struct SchemaResponse {
-    schema_validation: VecDeque<PathError>,
-}
-
-#[derive(Debug, Serialize)]
-struct PathError {
-    instance_location: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    keyword_location: Option<String>,
-    error: String,
-}
-
-impl From<JsonSchemaRejection> for JsonSchemaErrorResponse {
-    fn from(rejection: JsonSchemaRejection) -> Self {
-        match rejection {
-            JsonSchemaRejection::Json(v) => Self {
-                error: v.to_string(),
-                extra: AdditionalError::Json,
-            },
-            JsonSchemaRejection::Path(p) => Self {
-                error: p.to_string(),
-                extra: AdditionalError::Path,
-            },
-            JsonSchemaRejection::Serde(s) => Self {
-                error: "deserialization failed".to_string(),
-                extra: AdditionalError::Deserialization(DeserializationResponse {
-                    deserialization_error: VecDeque::from([PathError {
-                        // keys and index seperated by a '/'
-                        // enum is ignored because it doesn't exist in json
-                        instance_location: std::iter::once(String::new())
-                            .chain(s.path().iter().map(|s| match s {
-                                Segment::Map { key } => key.to_string(),
-                                Segment::Seq { index } => index.to_string(),
-                                _ => "?".to_string(),
-                            }))
-                            .join("/"),
-                        keyword_location: None,
-                        error: s.into_inner().to_string(),
-                    }]),
-                }),
-            },
-            JsonSchemaRejection::Schema(s) => Self {
-                error: "request schema validation failed".to_string(),
-                extra: AdditionalError::Schema(SchemaResponse {
-                    schema_validation: s
-                        .into_iter()
-                        .map(|v| PathError {
-                            instance_location: v.instance_location().to_string(),
-                            keyword_location: Some(v.keyword_location().to_string()),
-                            error: v.error_description().to_string(),
-                        })
-                        .collect(),
-                }),
-            },
-        }
-    }
-}
-
-impl IntoResponse for JsonSchemaRejection {
-    fn into_response(self) -> axum::response::Response {
-        let mut res = axum::Json(JsonSchemaErrorResponse::from(self)).into_response();
-        *res.status_mut() = StatusCode::BAD_REQUEST;
-        res
-    }
-}
-
-#[cfg(feature = "aide")]
-mod impl_aide {
-    use super::*;
-
-    impl<T> aide::OperationInput for Json<T>
-    where
-        T: JsonSchema,
-    {
-        fn operation_input(
-            ctx: &mut aide::gen::GenContext,
-            operation: &mut aide::openapi::Operation,
-        ) {
-            axum::Json::<T>::operation_input(ctx, operation);
-        }
-    }
-
-    impl<T> aide::OperationOutput for Json<T>
-    where
-        T: JsonSchema,
-    {
-        type Inner = <axum::Json<T> as aide::OperationOutput>::Inner;
-
-        fn operation_response(
-            ctx: &mut aide::gen::GenContext,
-            op: &mut aide::openapi::Operation,
-        ) -> Option<aide::openapi::Response> {
-            axum::Json::<T>::operation_response(ctx, op)
-        }
-
-        fn inferred_responses(
-            ctx: &mut aide::gen::GenContext,
-            operation: &mut aide::openapi::Operation,
-        ) -> Vec<(Option<u16>, aide::openapi::Response)> {
-            axum::Json::<T>::inferred_responses(ctx, operation)
         }
     }
 }

--- a/examples/example-axum/src/extractors.rs
+++ b/examples/example-axum/src/extractors.rs
@@ -1,6 +1,6 @@
 use aide::operation::OperationIo;
 use axum::response::IntoResponse;
-use axum_jsonschema::JsonSchemaRejection;
+use axum_jsonschema::extract::{JsonRejection, SerdeSchemaRejection};
 use axum_macros::FromRequest;
 use serde::Serialize;
 use serde_json::json;
@@ -8,10 +8,10 @@ use serde_json::json;
 use crate::errors::AppError;
 
 #[derive(FromRequest, OperationIo)]
-#[from_request(via(axum_jsonschema::Json), rejection(AppError))]
+#[from_request(via(axum_jsonschema::extract::Json), rejection(AppError))]
 #[aide(
-    input_with = "axum_jsonschema::Json<T>",
-    output_with = "axum_jsonschema::Json<T>",
+    input_with = "axum_jsonschema::extract::Json<T>",
+    output_with = "axum_jsonschema::extract::Json<T>",
     json_schema
 )]
 pub struct Json<T>(pub T);
@@ -25,15 +25,16 @@ where
     }
 }
 
-impl From<JsonSchemaRejection> for AppError {
-    fn from(rejection: JsonSchemaRejection) -> Self {
+impl From<JsonRejection> for AppError {
+    fn from(rejection: JsonRejection) -> Self {
         match rejection {
-            JsonSchemaRejection::Json(j) => Self::new(&j.to_string()),
-            JsonSchemaRejection::Path(_) => unreachable!("Not using Path extractor"),
-            JsonSchemaRejection::Serde(_) => Self::new("invalid request"),
-            JsonSchemaRejection::Schema(s) => {
-                Self::new("invalid request").with_details(json!({ "schema_validation": s }))
-            }
+            JsonRejection::Json(j) => Self::new(&j.to_string()),
+            JsonRejection::SerdeSchema(e) => match e {
+                SerdeSchemaRejection::Serde(_) => Self::new("invalid request"),
+                SerdeSchemaRejection::Schema(s) => {
+                    Self::new("invalid request").with_details(json!({ "schema_validation": s }))
+                }
+            },
         }
     }
 }

--- a/examples/example-axum/src/extractors.rs
+++ b/examples/example-axum/src/extractors.rs
@@ -29,6 +29,7 @@ impl From<JsonSchemaRejection> for AppError {
     fn from(rejection: JsonSchemaRejection) -> Self {
         match rejection {
             JsonSchemaRejection::Json(j) => Self::new(&j.to_string()),
+            JsonSchemaRejection::Path(_) => unreachable!("Not using Path extractor"),
             JsonSchemaRejection::Serde(_) => Self::new("invalid request"),
             JsonSchemaRejection::Schema(s) => {
                 Self::new("invalid request").with_details(json!({ "schema_validation": s }))

--- a/examples/example-axum/src/todos/routes.rs
+++ b/examples/example-axum/src/todos/routes.rs
@@ -6,7 +6,7 @@ use aide::{
     transform::TransformOperation,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
-use axum_jsonschema::extract::Path;
+use axum_jsonschema::extract::{Path, Query};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -151,9 +151,17 @@ struct SearchTodo {
     query: String,
 }
 
+#[derive(Deserialize, JsonSchema)]
+struct SelectTodoQuery {
+    /// The search query.
+    #[serde(rename = "id")]
+    _id: Option<Uuid>,
+}
+
 async fn search_todo(
     State(app): State<AppState>,
     Path(search): Path<SearchTodo>,
+    Query(_id): Query<SelectTodoQuery>,
 ) -> impl IntoApiResponse {
     Json(TodoList {
         todo_ids: app

--- a/examples/example-axum/src/todos/routes.rs
+++ b/examples/example-axum/src/todos/routes.rs
@@ -6,7 +6,7 @@ use aide::{
     transform::TransformOperation,
 };
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
-use axum_jsonschema::Path;
+use axum_jsonschema::extract::Path;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;


### PR DESCRIPTION
This is not done, but would like to request feedback on this approach.

Also, I got a question; the `axum::Json::from_request` already does deserialize so the code below would never return an `Err`(in theory?).

https://github.com/tamasfe/aide/blob/be3b6d77c21d94e67d45428f534db75c6be3bd98/crates/axum-jsonschema/src/lib.rs#L96-L99

Maybe do a `trace::error` and do something else? Not sure what, but it feel like the error shouldn't be exposed to crate users.