### PR TITLE
Updated jwt-authorizer dependency version

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -31,7 +31,7 @@ cfg-if = "1.0.0"
 
 # custom axum extractors
 serde_qs = { version = "0.12.0", optional = true }
-jwt-authorizer = { version = "0.13", default-features = false, optional = true }
+jwt-authorizer = { version = "0.14", default-features = false, optional = true }
 
 [features]
 macros = ["dep:aide-macros"]


### PR DESCRIPTION
jwt-authorizer 0.13 is incompatible with the current aide due to its dependence on axum 0.6