### PR TITLE
Replace derive_more derives with manual implementations

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = "1"
 thiserror = "1"
 tracing = "0"
 aide-macros = { version = "0.7.0", path = "../aide-macros", optional = true }
-derive_more = "0.99.17"
 
 bytes = { version = "1", optional = true }
 http = { version = "1.0.0", optional = true }

--- a/crates/aide/src/helpers/no_api.rs
+++ b/crates/aide/src/helpers/no_api.rs
@@ -1,9 +1,10 @@
-use derive_more::{AsMut, AsRef, Deref, DerefMut, From};
+use std::ops::{Deref, DerefMut};
+
 use serde::{Deserialize, Serialize};
 
 use crate::{OperationInput, OperationOutput};
 
-/// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a default empty documentation.  
+/// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a default empty documentation.
 /// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation and hides it.
 /// ```ignore
 /// pub async fn my_sqlx_tx_endpoint(
@@ -11,29 +12,45 @@ use crate::{OperationInput, OperationOutput};
 /// ) -> NoApi<Json<YourResult>> // Hides the API of the return type
 /// # {}
 /// ```
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    Serialize,
-    Deserialize,
-    Deref,
-    DerefMut,
-    AsRef,
-    AsMut,
-    From,
-)]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct NoApi<T>(pub T);
 
 impl<T> NoApi<T> {
     /// Unwraps [Self] into its inner type
     pub fn into_inner(self) -> T {
         self.0
+    }
+}
+
+impl<T> Deref for NoApi<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for NoApi<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> AsRef<T> for NoApi<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> AsMut<T> for NoApi<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for NoApi<T> {
+    fn from(value: T) -> Self {
+        Self(value)
     }
 }
 

--- a/crates/aide/src/helpers/no_api.rs
+++ b/crates/aide/src/helpers/no_api.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{OperationInput, OperationOutput};
 
 /// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a default empty documentation.
+///
 /// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation and hides it.
 /// ```ignore
 /// pub async fn my_sqlx_tx_endpoint(

--- a/crates/aide/src/helpers/use_api.rs
+++ b/crates/aide/src/helpers/use_api.rs
@@ -1,6 +1,8 @@
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
-use derive_more::{AsMut, AsRef, Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 
 use crate::gen::GenContext;
@@ -25,41 +27,45 @@ impl<T> IntoApi for T {
 
 /// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with the api documentation of [A].
 /// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation with the provided one.
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    Serialize,
-    Deserialize,
-    Deref,
-    DerefMut,
-    AsRef,
-    AsMut,
-)]
-pub struct UseApi<T, A>(
-    #[as_ref]
-    #[as_mut]
-    #[deref]
-    #[deref_mut]
-    pub T,
-    pub PhantomData<A>,
-);
-
-impl<T, A> From<T> for UseApi<T, A> {
-    fn from(value: T) -> Self {
-        Self(value, Default::default())
-    }
-}
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct UseApi<T, A>(pub T, pub PhantomData<A>);
 
 impl<T, A> UseApi<T, A> {
     /// Unwraps [Self] into its inner type
     pub fn into_inner(self) -> T {
         self.0
+    }
+}
+
+impl<T, A> Deref for UseApi<T, A> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T, A> DerefMut for UseApi<T, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T, A> AsRef<T> for UseApi<T, A> {
+    fn as_ref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T, A> AsMut<T> for UseApi<T, A> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+impl<T, A> From<T> for UseApi<T, A> {
+    fn from(value: T) -> Self {
+        Self(value, Default::default())
     }
 }
 

--- a/crates/aide/src/helpers/use_api.rs
+++ b/crates/aide/src/helpers/use_api.rs
@@ -26,6 +26,7 @@ impl<T> IntoApi for T {
 }
 
 /// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with the api documentation of [A].
+///
 /// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation with the provided one.
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct UseApi<T, A>(pub T, pub PhantomData<A>);

--- a/crates/aide/src/helpers/with_api.rs
+++ b/crates/aide/src/helpers/with_api.rs
@@ -10,6 +10,7 @@ use crate::openapi::{Operation, Response};
 use crate::{OperationInput, OperationOutput};
 
 /// Trait that allows implementing a custom Api definition for any type.
+///
 /// Two approaches are possible:
 ///
 /// 1. Simple Type override for concrete types
@@ -65,6 +66,7 @@ pub trait ApiOverride {
 }
 
 /// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a provided documentation.
+///
 /// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation with the provided one.
 /// See [`ApiOverride`] on how to implement such an override
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/crates/aide/src/helpers/with_api.rs
+++ b/crates/aide/src/helpers/with_api.rs
@@ -1,6 +1,8 @@
-use std::marker::PhantomData;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
-use derive_more::{AsMut, AsRef, Deref, DerefMut};
 use serde::{Deserialize, Serialize};
 
 use crate::gen::GenContext;
@@ -62,33 +64,11 @@ pub trait ApiOverride {
     type Target;
 }
 
-/// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a provided documentation.  
+/// Allows non [`OperationInput`] or [`OperationOutput`] types to be used in aide handlers with a provided documentation.
 /// For types that already implement [`OperationInput`] or [`OperationOutput`] it overrides the documentation with the provided one.
 /// See [`ApiOverride`] on how to implement such an override
-#[derive(
-    Copy,
-    Clone,
-    Debug,
-    Ord,
-    PartialOrd,
-    Eq,
-    PartialEq,
-    Hash,
-    Serialize,
-    Deserialize,
-    Deref,
-    DerefMut,
-    AsRef,
-    AsMut,
-)]
-pub struct WithApi<T>(
-    #[as_ref]
-    #[as_mut]
-    #[deref]
-    #[deref_mut]
-    pub T::Target,
-    pub PhantomData<T>,
-)
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct WithApi<T>(pub T::Target, pub PhantomData<T>)
 where
     T: ApiOverride;
 
@@ -99,6 +79,44 @@ where
     /// Unwraps [Self] into its inner type
     pub fn into_inner(self) -> T::Target {
         self.0
+    }
+}
+
+impl<T> Deref for WithApi<T>
+where
+    T: ApiOverride,
+{
+    type Target = T::Target;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for WithApi<T>
+where
+    T: ApiOverride,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> AsRef<T::Target> for WithApi<T>
+where
+    T: ApiOverride,
+{
+    fn as_ref(&self) -> &T::Target {
+        &self.0
+    }
+}
+
+impl<T> AsMut<T::Target> for WithApi<T>
+where
+    T: ApiOverride,
+{
+    fn as_mut(&mut self) -> &mut T::Target {
+        &mut self.0
     }
 }
 


### PR DESCRIPTION
Do you want me to try `macro_rules!` "derives" as an alternative? I think due to all the types here being generic, that would probably only save a few lines and the macro code would be a tad hard to read, so I'd personally prefer this for readability. It's not that much boilerplate IMHO.

Resolves #122.