### PR TITLE
OpenApi security schemes support

### DIFF
--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -2,15 +2,14 @@
 use crate::{
     openapi::{
         self, Header, MediaType, Operation, Parameter, ParameterData, ReferenceOr, RequestBody,
-        Response, SchemaObject, StatusCode,
+        Response, SchemaObject, SecurityScheme, StatusCode,
     },
     operation::{add_parameters, set_body},
 };
 use axum::{
     body::Body,
     extract::{
-        Extension, Form, Host, Json, MatchedPath, OriginalUri, Path, Query, RawQuery,
-        State,
+        Extension, Form, Host, Json, MatchedPath, OriginalUri, Path, Query, RawQuery, State,
     },
 };
 
@@ -410,6 +409,8 @@ mod extra {
 
 #[cfg(feature = "jwt-authorizer")]
 mod jwt_authorizer {
+    use std::any::type_name;
+
     use super::*;
     use crate::OperationInput;
     use ::jwt_authorizer::JwtClaims;
@@ -419,31 +420,18 @@ mod jwt_authorizer {
             ctx: &mut crate::gen::GenContext,
             operation: &mut crate::openapi::Operation,
         ) {
-            let s = ctx.schema.subschema_for::<String>();
-            add_parameters(
-                ctx,
-                operation,
-                [Parameter::Header {
-                    parameter_data: ParameterData {
-                        name: "Authorization".to_string(),
-                        description: Some("Jwt Bearer token".to_string()),
-                        required: true,
-                        format: crate::openapi::ParameterSchemaOrContent::Schema(
-                            openapi::SchemaObject {
-                                json_schema: s,
-                                example: None,
-                                external_docs: None,
-                            },
-                        ),
-                        extensions: Default::default(),
-                        deprecated: None,
-                        example: None,
-                        examples: IndexMap::default(),
-                        explode: None,
-                    },
-                    style: openapi::HeaderStyle::Simple,
-                }],
+            let t = "JWT Authorizer".to_string();
+            ctx.security_schemes.insert(
+                t.clone(),
+                ReferenceOr::Item(SecurityScheme::Http {
+                    scheme: "Bearer".to_string(),
+                    bearer_format: Some("JWT".to_string()),
+                    description: Some("A bearer token.".to_string()),
+                    extensions: Default::default(),
+                }),
             );
+
+            operation.security.push([(t, Vec::new())].into())
         }
     }
 }

--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -394,6 +394,10 @@ where
                 let components = api.components.get_or_insert_with(Default::default);
 
                 components
+                    .security_schemes
+                    .extend(ctx.security_schemes.drain());
+
+                components
                     .schemas
                     .extend(ctx.schema.take_definitions().into_iter().map(
                         |(name, json_schema)| {

--- a/crates/aide/src/gen.rs
+++ b/crates/aide/src/gen.rs
@@ -49,9 +49,7 @@ pub fn on_error(handler: impl Fn(Error) + 'static) {
 ///
 /// [`OpenApi`]: crate::openapi::OpenApi
 pub fn extract_schemas(extract: bool) {
-    in_context(|ctx| {
-        ctx.set_extract_schemas(extract)
-    });
+    in_context(|ctx| ctx.set_extract_schemas(extract));
 }
 
 /// Set the inferred status code of empty responses (`()`).
@@ -105,6 +103,12 @@ pub struct GenContext {
     /// for generating JSON schemas.
     pub schema: SchemaGenerator,
 
+    /// Secutiry schemes descriptions.
+    pub security_schemes: std::collections::HashMap<
+        String,
+        crate::openapi::ReferenceOr<crate::openapi::SecurityScheme>,
+    >,
+
     pub(crate) infer_responses: bool,
 
     pub(crate) all_error_responses: bool,
@@ -134,6 +138,7 @@ impl GenContext {
 
         let mut this = Self {
             schema: SchemaGenerator::new(SchemaSettings::draft07()),
+            security_schemes: std::collections::HashMap::new(),
             infer_responses: true,
             all_error_responses: false,
             extract_schemas: true,


### PR DESCRIPTION
I managed to implement an OpenApi security schemes as shown [here](https://swagger.io/docs/specification/authentication/) so JWT authorization will be shown in a specific chapter and not amongst other headers.
I'm not sure if I did it right though as it needs a name for each authorization to be assigned. I decided to use constant name `"JWT authorizer"` as there is no difference in a presentation of the API between separate jwt authorizations after all even if one decides to use many authorization layers. As an option, it is possible to use `type_name::<T> `of `T` from `JwtClaims<T>` but this will lead to an inner structure leakage to the API. Maybe there are other ways but I can't come up with one.