### PR TITLE
fix: remove trailing / from nested paths

### DIFF
--- a/crates/aide/src/util.rs
+++ b/crates/aide/src/util.rs
@@ -41,6 +41,18 @@ pub fn iter_operations_mut(
     vec.into_iter()
 }
 
+/// Helper function for nesting functions in Axum.
+/// Based on Axum's own implementation of nested paths.
+pub(crate) fn path_for_nested_route<'a>(path: &'a str, route: &'a str) -> String {    
+    if path.ends_with('/') {
+        format!("{path}{}", route.trim_start_matches('/')).into()
+    } else if route == "/" {
+        path.into()
+    } else {
+        format!("{path}{route}").into()
+    }
+}
+
 pub(crate) fn merge_paths(ctx: &mut GenContext, path: &str, target: &mut PathItem, from: PathItem) {
     if let Some(op) = from.get {
         if target.get.is_some() {

--- a/crates/aide/src/util.rs
+++ b/crates/aide/src/util.rs
@@ -42,8 +42,9 @@ pub fn iter_operations_mut(
 }
 
 /// Helper function for nesting functions in Axum.
+///
 /// Based on Axum's own implementation of nested paths.
-pub(crate) fn path_for_nested_route<'a>(path: &'a str, route: &'a str) -> String {    
+pub(crate) fn path_for_nested_route<'a>(path: &'a str, route: &'a str) -> String {
     if path.ends_with('/') {
         format!("{path}{}", route.trim_start_matches('/')).into()
     } else if route == "/" {


### PR DESCRIPTION
Hi!

This PR attempts to fix https://github.com/tamasfe/aide/issues/134.

Currently, API documentation for nested routes is built by combining the path of the base route (with trailing slashes removed) with the path of the nested route.

If a path of a nested route is only "/", as seen in the todo list example, this leads to that path now containing a trailing slash:

```rust
ApiRouter::new().nest_api_service("/todo", ApiRouter::new().api_route("/",post_with(handler, docs)))
```

Generates this path:

```json
"paths": {
    "/todo/": {
        ...
    },
    ...
}
```

This PR fixes this issue by removing any trailing slahes after the nested path is built in the `nest` and `nest_api_service` functions.

One edge case needs to be handled. In a construct like the following:

```rust
ApiRouter::new().nest_api_service("/", ApiRouter::new().api_route("/",post_with(handler, docs)))
```

the path of this route would be empty. A route of just `/` is therefore returned unmodified.

I've also added a basic unit test.

This seems to be a simple fix, I hope I didn't miss any other cases here.