### PR TITLE
security_scheme: http, bearer_format should be string or omitted

### DIFF
--- a/crates/aide/src/openapi/security_scheme.rs
+++ b/crates/aide/src/openapi/security_scheme.rs
@@ -26,6 +26,7 @@ pub enum SecurityScheme {
     Http {
         scheme: String,
         #[serde(rename = "bearerFormat")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         bearer_format: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,


### PR DESCRIPTION
It causes issues with scalar making auth unusable if bearer_format is set to `None`.