### PR TITLE
Release v0.13.5

### DIFF
--- a/crates/aide/CHANGELOG.md
+++ b/crates/aide/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.13.5
+
+- **added:** Implement `OperationHandler` for `axum::handler::Layered` ([#133])
+- **added:** Implement `OperationInput` for `axum_extra::extract::JsonDeserializer` ([#151])
+- **changed:** Make `impl tower::Service for ApiRouter` generic over the HTTP request body type ([#143])
+
+[#133]: https://github.com/tamasfe/aide/pull/133
+[#143]: https://github.com/tamasfe/aide/pull/143
+[#151]: https://github.com/tamasfe/aide/pull/151
+
 ## 0.13.4 - 2024-04-14
 
 [f473a8c](f473a8c98e1b41c8d67a4d25141ac12d57c5182a)...[bd273ad](bd273ad63df2245384a7b7e5951003aa60c53d72)

--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide"
-version = "0.13.4"
+version = "0.13.5"
 authors = ["tamasfe"]
 edition = "2021"
 keywords = ["generate", "api", "openapi", "documentation", "specification"]


### PR DESCRIPTION
I would like to release v0.13.5. [`cargo semver-checks`](https://github.com/obi1kenobi/cargo-semver-checks) reports no breakage since the last release.
I'd run `cargo publish` locally after this is merged if that's fine with you.

Please don't merge this PR on my behalf, I prefer merging myself once approved on repos where I have write access.