### PR TITLE
SchemaGenerator: use OpenAPI 3.0 instead of JSON Schema Draft 7

### DIFF
--- a/crates/aide/src/gen.rs
+++ b/crates/aide/src/gen.rs
@@ -133,7 +133,7 @@ impl GenContext {
         }
 
         let mut this = Self {
-            schema: SchemaGenerator::new(SchemaSettings::draft07()),
+            schema: SchemaGenerator::new(SchemaSettings::openapi3()),
             infer_responses: true,
             all_error_responses: false,
             extract_schemas: true,
@@ -150,13 +150,12 @@ impl GenContext {
     }
     fn set_extract_schemas(&mut self, extract: bool) {
         if extract {
-            self.schema = SchemaGenerator::new(SchemaSettings::draft07().with(|s| {
+            self.schema = SchemaGenerator::new(SchemaSettings::openapi3().with(|s| {
                 s.inline_subschemas = false;
-                s.definitions_path = "#/components/schemas/".into();
             }));
             self.extract_schemas = true;
         } else {
-            self.schema = SchemaGenerator::new(SchemaSettings::draft07().with(|s| {
+            self.schema = SchemaGenerator::new(SchemaSettings::openapi3().with(|s| {
                 s.inline_subschemas = true;
             }));
             self.extract_schemas = false;

--- a/crates/axum-jsonschema/src/lib.rs
+++ b/crates/axum-jsonschema/src/lib.rs
@@ -121,7 +121,7 @@ struct SchemaContext {
 impl SchemaContext {
     fn new() -> Self {
         Self {
-            generator: SchemaSettings::draft07()
+            generator: SchemaSettings::openapi3()
                 .with(|g| g.inline_subschemas = true)
                 .into_generator(),
             schemas: HashMap::default(),


### PR DESCRIPTION
We are using scalar, currently in browser debug console we are getting bunch of Schema errors, one example:
```
 {
  "_errors": [],
  "type": {
    "_errors": [
      "Expected string, received array"
    ]
  }
}
``` 

After going trough [schemars docs](https://docs.rs/schemars/latest/schemars/gen/struct.SchemaSettings.html#impl-SchemaSettings)  I've noticed that there is a option to conform to openapi3 spec, additionally [svix-server](https://github.com/svix/svix-webhooks/blob/main/server/svix-server/src/openapi.rs#L17) is already using it.

With this simple change all of the debug console errors are gone.

Let me know if I'm missing something.