### PR TITLE
suggestion: custom aide build-script to autoupdate Static Files

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/tamasfe/aide"
 description = "A code-first API documentation library"
 readme = "README.md"
+build = "build.rs"
 
 [dependencies]
 indexmap = { version = "2.1", features = ["serde"] }
@@ -38,6 +39,7 @@ redoc = []
 swagger = []
 scalar = []
 skip_serializing_defaults = []
+update_docs = []
 
 axum = ["dep:axum", "bytes", "http", "dep:tower-layer", "dep:tower-service", "serde_qs?/axum"]
 axum-headers = ["axum-extra/typed-header"]
@@ -58,6 +60,9 @@ jwt-authorizer = ["dep:jwt-authorizer"]
 [dev-dependencies]
 serde = { version = "1.0.144", features = ["derive"] }
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
+
+[build-dependencies]
+reqwest = { version = "0.12.12", features = ["blocking"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/aide/build.rs
+++ b/crates/aide/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+
+static UPDATE_DOCS_DB: [(&str, &str); 2] = [
+    ("./res/swagger/swagger-ui.css", "https://raw.githubusercontent.com/swagger-api/swagger-ui/refs/heads/master/dist/swagger-ui.css"),
+    ("./res/swagger/swagger-ui-bundle.js", "https://raw.githubusercontent.com/swagger-api/swagger-ui/refs/heads/master/dist/swagger-ui-bundle.js"),
+];
+
+fn main() {
+    if env::var("CARGO_FEATURE_UPDATE_DOCS").is_ok() {
+        for entry in UPDATE_DOCS_DB.iter() {
+            println!("cargo:rerun-if-changed={}", entry.0);
+            update_docs(entry);
+        }
+    }
+}
+
+fn update_docs(entry: &(&str, &str)) {
+    reqwest::blocking::get(entry.1)
+        .unwrap()
+        .copy_to(&mut std::fs::File::create(entry.0).unwrap())
+        .unwrap();
+}


### PR DESCRIPTION
This was a quick idea to fix the reoccurring issue of outdated Docs. The Idea here was to use the build script to grab the latest version of the static files. 
This will only work, if we have a static url for the trusted files. For example the master branch of the official Repository. That way we don't need to approve each version bump of the Documentation provider.

This should be Locked behind a feature, because this feature requires an Internet connection for building.

Any Ideas?