### PR TITLE
Update README to remove dropped crates in v0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 - [Aide](#aide)
   - [Crates](#crates)
     - [aide](#aide-1)
-    - [axum-jsonschema](#axum-jsonschema)
     - [aide-axum-sqlx-tx](#aide-axum-sqlx-tx)
     - [aide-axum-typed-multipart](#aide-axum-typed-multipart)
   - [Contributing](#contributing)
@@ -23,12 +22,6 @@ This repository contains several crates related to web-servers and their documen
 A code-first API documentation and utility library.
 
 Read the [docs](https://docs.rs/aide/latest/aide/).
-
-### axum-jsonschema
-
-A JSON request validation library for [axum](https://github.com/tokio-rs/axum).
-
-Read the [docs](https://docs.rs/axum-jsonschema/latest/axum_jsonschema/).
 
 ### [aide-axum-sqlx-tx](./crates/aide-axum-sqlx-tx/README.md)
 


### PR DESCRIPTION
- [Drop axum-jsonschema crate](https://github.com/tamasfe/aide/commit/87df30b33e80c29d9985b15df96d7c456fb70e7b)
- [Drop aide-axum-typed-multipart crate](https://github.com/tamasfe/aide/commit/b6140d8d02633b19c732ac0a73cea56e53bac1d9)
- [Drop aide-axum-sqlx-tx crate](https://github.com/tamasfe/aide/commit/68cdbaa51d58cccb6b9fdb466d9707650f716c2a)

What is unclear is what users should do trying to update to the [v0.14.0 release](https://github.com/tamasfe/aide/releases/tag/release-aide-0.14.0) and need to depend on axum 0.8 that includes some breaking feature gating at least (from what I can tell attempting to update a [toy project](https://github.com/nuke-web3/axum-file-stream-demo/). Might maintainers advise here? Thanks!