### PR TITLE
Release v0.14.1

### DIFF
--- a/crates/aide-macros/Cargo.toml
+++ b/crates/aide-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide-macros"
-version = "0.8.0"
+version = "0.8.0" # remember to update the dependency in aide, even for patch releases
 authors = ["tamasfe"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/aide/CHANGELOG.md
+++ b/crates/aide/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.14.1
+
+- **fixed:** Update the outdated feature list in the crate root documentation ([#186])
+- **added:** Implement OperationOutput for axum::response::NoContent ([#184])
+
+[#184]: https://github.com/tamasfe/aide/pull/184
+[#186]: https://github.com/tamasfe/aide/pull/186
+
 ## 0.14.0
 
 - **breaking:** Upgrade `axum` to `0.8` ([#168])

--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1"
 thiserror = "2.0"
 tracing = "0.1"
-aide-macros = { version = "0.8.0", path = "../aide-macros", optional = true }
+aide-macros = { version = "=0.8.0", path = "../aide-macros", optional = true }
 
 bytes = { version = "1", optional = true }
 http = { version = "1.0.0", optional = true }

--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aide"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["tamasfe"]
 edition = "2021"
 keywords = ["generate", "api", "openapi", "documentation", "specification"]


### PR DESCRIPTION
… and use an exact version requirement for aide-macros dependency.

In case we add new things to the macros crate that depend on new
functionality from the main crate, it's important that the macro crate
is not upgraded in a downstream project without the main crate being
updated.