### PR TITLE
fix: infer early responses in `OperationInput` implementation for tuples

### DIFF
--- a/crates/aide/src/operation.rs
+++ b/crates/aide/src/operation.rs
@@ -84,6 +84,14 @@ macro_rules! impl_operation_input {
                     $ty::operation_input(ctx, operation);
                 )*
             }
+
+            fn inferred_early_responses(ctx: &mut GenContext, operation: &mut Operation) -> Vec<(Option<u16>, Response)> {
+                let mut responses = Vec::new();
+                $(
+                    responses.extend($ty::inferred_early_responses(ctx, operation));
+                )*
+                responses
+            }
         }
     };
 }


### PR DESCRIPTION
For axum handlers, aide collects their extractors' inferred early responses:

https://github.com/tamasfe/aide/blob/95723fb9990aaa9ff0fa91a730a01c15ea4a073a/crates/aide/src/axum/routing.rs#L175-L187

...except that the `I` here is always a tuple, and tuples currently use the default implementation of `inferred_early_responses` which always returned no responses. So I added an override which collects early responses from all extractors.