### PR TITLE
Return `StatusCode` instead of `u16` for inferred responses

### DIFF
--- a/crates/aide/src/axum/outputs.rs
+++ b/crates/aide/src/axum/outputs.rs
@@ -1,5 +1,5 @@
 use crate::{
-    openapi::{MediaType, Operation, Response, SchemaObject},
+    openapi::{MediaType, Operation, Response, SchemaObject, StatusCode},
     util::no_content_response,
 };
 #[cfg(feature = "axum-form")]
@@ -7,8 +7,6 @@ use axum::extract::rejection::FormRejection;
 #[cfg(feature = "axum-json")]
 use axum::extract::rejection::JsonRejection;
 use axum::response::{Html, NoContent, Redirect};
-#[cfg(any(feature = "axum-json", feature = "axum-form"))]
-use http::StatusCode;
 use indexmap::IndexMap;
 use schemars::schema::{InstanceType, SingleOrVec};
 #[cfg(any(feature = "axum-form", feature = "axum-json"))]
@@ -26,8 +24,8 @@ impl OperationOutput for NoContent {
     fn inferred_responses(
         _ctx: &mut GenContext,
         _operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
-        vec![(Some(204), no_content_response())]
+    ) -> Vec<(Option<StatusCode>, Response)> {
+        vec![(Some(StatusCode::Code(204)), no_content_response())]
     }
 }
 
@@ -61,9 +59,9 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            let success_response = [(Some(200), res)];
+            let success_response = [(Some(StatusCode::Code(200)), res)];
 
             if ctx.all_error_responses {
                 [
@@ -110,9 +108,9 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            let success_response = [(Some(200), res)];
+            let success_response = [(Some(StatusCode::Code(200)), res)];
 
             if ctx.all_error_responses {
                 [
@@ -159,9 +157,9 @@ impl<T> OperationOutput for Html<T> {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            Vec::from([(Some(200), res)])
+            Vec::from([(Some(StatusCode::Code(200)), res)])
         } else {
             Vec::new()
         }
@@ -179,12 +177,18 @@ impl OperationOutput for JsonRejection {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
             Vec::from([
                 // rejection_response(StatusCode::BAD_REQUEST, &res),
-                rejection_response(StatusCode::PAYLOAD_TOO_LARGE, &res),
-                rejection_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, &res),
+                rejection_response(
+                    StatusCode::Code(http::StatusCode::PAYLOAD_TOO_LARGE.into()),
+                    &res,
+                ),
+                rejection_response(
+                    StatusCode::Code(http::StatusCode::UNSUPPORTED_MEDIA_TYPE.into()),
+                    &res,
+                ),
                 // rejection_response(StatusCode::UNPROCESSABLE_ENTITY, &res),
             ])
         } else {
@@ -204,12 +208,18 @@ impl OperationOutput for FormRejection {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
             Vec::from([
                 // rejection_response(StatusCode::BAD_REQUEST, &res),
-                rejection_response(StatusCode::PAYLOAD_TOO_LARGE, &res),
-                rejection_response(StatusCode::UNSUPPORTED_MEDIA_TYPE, &res),
+                rejection_response(
+                    StatusCode::Code(http::StatusCode::PAYLOAD_TOO_LARGE.into()),
+                    &res,
+                ),
+                rejection_response(
+                    StatusCode::Code(http::StatusCode::UNSUPPORTED_MEDIA_TYPE.into()),
+                    &res,
+                ),
                 // rejection_response(StatusCode::UNPROCESSABLE_ENTITY, &res),
             ])
         } else {
@@ -219,8 +229,11 @@ impl OperationOutput for FormRejection {
 }
 
 #[cfg(any(feature = "axum-json", feature = "axum-form"))]
-fn rejection_response(status_code: StatusCode, response: &Response) -> (Option<u16>, Response) {
-    (Some(status_code.as_u16()), response.clone())
+fn rejection_response(
+    status_code: StatusCode,
+    response: &Response,
+) -> (Option<StatusCode>, Response) {
+    (Some(status_code), response.clone())
 }
 
 impl OperationOutput for Redirect {

--- a/crates/aide/src/axum/routing.rs
+++ b/crates/aide/src/axum/routing.rs
@@ -201,7 +201,7 @@ macro_rules! method_router_top_level {
 fn set_inferred_response(
     ctx: &mut GenContext,
     operation: &mut Operation,
-    status: Option<u16>,
+    status: Option<StatusCode>,
     res: Response,
 ) {
     if operation.responses.is_none() {
@@ -212,12 +212,10 @@ fn set_inferred_response(
 
     match status {
         Some(status) => {
-            if responses.responses.contains_key(&StatusCode::Code(status)) {
-                ctx.error(Error::InferredResponseConflict(status));
+            if responses.responses.contains_key(&status) {
+                ctx.error(Error::InferredResponseConflict(status.to_string()));
             } else {
-                responses
-                    .responses
-                    .insert(StatusCode::Code(status), ReferenceOr::Item(res));
+                responses.responses.insert(status, ReferenceOr::Item(res));
             }
         }
         None => {

--- a/crates/aide/src/error.rs
+++ b/crates/aide/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[error(r#"transformations do not support references"#)]
     UnexpectedReference,
     #[error("did not apply inferred response because a response for status {0} already exists")]
-    InferredResponseConflict(u16),
+    InferredResponseConflict(String),
     #[error("did not apply inferred default response because a default response already exists")]
     InferredDefaultResponseConflict,
     #[error("{0}")]

--- a/crates/aide/src/helpers/use_api.rs
+++ b/crates/aide/src/helpers/use_api.rs
@@ -5,8 +5,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::generate::GenContext;
 use crate::openapi::{Operation, Response};
+use crate::{generate::GenContext, openapi::StatusCode};
 use crate::{OperationInput, OperationOutput};
 
 /// helper trait to allow simplified use of [`UseApi`] in responses
@@ -82,7 +82,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         A::inferred_early_responses(ctx, operation)
     }
 }
@@ -100,7 +100,7 @@ where
     fn inferred_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         A::inferred_responses(ctx, operation)
     }
 }

--- a/crates/aide/src/helpers/with_api.rs
+++ b/crates/aide/src/helpers/with_api.rs
@@ -5,8 +5,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::generate::GenContext;
 use crate::openapi::{Operation, Response};
+use crate::{generate::GenContext, openapi::StatusCode};
 use crate::{OperationInput, OperationOutput};
 
 /// Trait that allows implementing a custom Api definition for any type.
@@ -133,7 +133,7 @@ where
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_early_responses(ctx, operation)
     }
 }
@@ -151,7 +151,7 @@ where
     fn inferred_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_responses(ctx, operation)
     }
 }

--- a/crates/aide/src/impls/bytes.rs
+++ b/crates/aide/src/impls/bytes.rs
@@ -2,7 +2,7 @@ use bytes::{Bytes, BytesMut};
 use indexmap::IndexMap;
 
 use crate::{
-    openapi::{MediaType, Operation, RequestBody, Response},
+    openapi::{MediaType, Operation, RequestBody, Response, StatusCode},
     operation::set_body,
     OperationInput, OperationOutput,
 };
@@ -57,9 +57,9 @@ impl OperationOutput for Bytes {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            Vec::from([(Some(200), res)])
+            Vec::from([(Some(StatusCode::Code(200)), res)])
         } else {
             Vec::new()
         }
@@ -79,7 +79,7 @@ impl OperationOutput for BytesMut {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         Bytes::inferred_responses(ctx, operation)
     }
 }

--- a/crates/aide/src/impls/mod.rs
+++ b/crates/aide/src/impls/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, convert::Infallible, rc::Rc, sync::Arc};
 
 use crate::{
-    openapi::{MediaType, Operation, RequestBody, Response},
+    openapi::{MediaType, Operation, RequestBody, Response, StatusCode},
     operation::set_body,
     util::no_content_response,
     OperationInput,
@@ -27,7 +27,7 @@ where
     fn inferred_early_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_early_responses(ctx, operation)
     }
 }
@@ -49,7 +49,7 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         let mut responses = T::inferred_responses(ctx, operation);
         responses.extend(E::inferred_responses(ctx, operation));
         responses
@@ -106,7 +106,7 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_responses(ctx, operation)
     }
 }
@@ -136,7 +136,7 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_responses(ctx, operation)
     }
 }
@@ -166,7 +166,7 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_responses(ctx, operation)
     }
 }
@@ -196,7 +196,7 @@ where
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         T::inferred_responses(ctx, operation)
     }
 }
@@ -239,9 +239,9 @@ impl OperationOutput for String {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            Vec::from([(Some(200), res)])
+            Vec::from([(Some(StatusCode::Code(200)), res)])
         } else {
             Vec::new()
         }
@@ -261,7 +261,7 @@ impl OperationOutput for &str {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         String::inferred_responses(ctx, operation)
     }
 }
@@ -279,7 +279,7 @@ impl OperationOutput for Cow<'_, str> {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         String::inferred_responses(ctx, operation)
     }
 }
@@ -297,9 +297,9 @@ impl OperationOutput for () {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            Vec::from([(Some(ctx.no_content_status), res)])
+            Vec::from([(Some(StatusCode::Code(ctx.no_content_status)), res)])
         } else {
             Vec::new()
         }
@@ -347,9 +347,9 @@ impl OperationOutput for Vec<u8> {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         if let Some(res) = Self::operation_response(ctx, operation) {
-            Vec::from([(Some(200), res)])
+            Vec::from([(Some(StatusCode::Code(200)), res)])
         } else {
             Vec::new()
         }
@@ -378,7 +378,7 @@ impl OperationOutput for &[u8] {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         Vec::<u8>::inferred_responses(ctx, operation)
     }
 }
@@ -405,7 +405,7 @@ impl OperationOutput for Cow<'_, [u8]> {
     fn inferred_responses(
         ctx: &mut crate::generate::GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         Vec::<u8>::inferred_responses(ctx, operation)
     }
 }

--- a/crates/aide/src/operation.rs
+++ b/crates/aide/src/operation.rs
@@ -6,6 +6,7 @@ use schemars::schema::SchemaObject;
 use crate::generate::GenContext;
 use crate::openapi::{
     self, Operation, Parameter, ParameterData, QueryStyle, ReferenceOr, RequestBody, Response,
+    StatusCode,
 };
 use crate::Error;
 
@@ -65,7 +66,7 @@ pub trait OperationInput {
     fn inferred_early_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         Vec::new()
     }
 }
@@ -168,7 +169,7 @@ pub trait OperationOutput {
     fn inferred_responses(
         ctx: &mut GenContext,
         operation: &mut Operation,
-    ) -> Vec<(Option<u16>, Response)> {
+    ) -> Vec<(Option<StatusCode>, Response)> {
         Vec::new()
     }
 }


### PR DESCRIPTION
Inferred responses now uses an explicit `StatusCode`, allowing you to specify ranged status codes. This is typically useful for app-wide error types:

```rust
#[derive(Deserialize, JsonSchema)]
struct AppError {
    message: String,
}

impl OperationOutput for AppError {
    type Inner = ();

    fn operation_response(ctx: &mut GenContext, _operation: &mut Operation) -> Option<Response> {
        ...
    }

    fn inferred_responses(
        ctx: &mut GenContext,
        operation: &mut Operation,
    ) -> Vec<(Option<StatusCode>, Response)> {
        if let Some(res) = Self::operation_response(ctx, operation) {
            vec![(Some(StatusCode::Range(4)), res)] // <-- ranged status codes!
        } else {
            Vec::new()
        }
    }
}
```

You can then use the type in your routes:

```rust
async fn greet(Json(String): Json<String>) -> Result<String, AppError> { // <-- neat return type
    Ok(format!("hello {name}!"))
}
```

Which aide will then automatically infer:

```jsonc
"4XX": { // <-- correct inference
  "description": "",
  "content": {
    "application/json": {
      "schema": {
        "$ref": "#/components/schemas/ApiError"
      }
    }
  }
}
```