### PR TITLE
Bring back serde_qs, bump to v0.14

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -20,6 +20,7 @@ aide-macros = { version = "=0.8.0", path = "../aide-macros", optional = true }
 
 bytes = { version = "1", optional = true }
 http = { version = "1.0.0", optional = true }
+serde_qs = { version = "0.14", optional = true }
 
 axum = { version = "0.8.1", optional = true, default-features = false }
 axum-extra = { version = "0.10.0", optional = true }
@@ -33,8 +34,9 @@ redoc = []
 swagger = []
 scalar = []
 skip_serializing_defaults = []
+serde_qs = ["dep:serde_qs"]
 
-axum = ["dep:axum", "bytes", "http", "dep:tower-layer", "dep:tower-service"]
+axum = ["dep:axum", "bytes", "http", "dep:tower-layer", "dep:tower-service", "serde_qs?/axum"]
 axum-form = ["axum", "axum/form"]
 axum-json = ["axum", "axum/json"]
 axum-matched-path = ["axum", "axum/matched-path"]

--- a/crates/aide/src/impls/mod.rs
+++ b/crates/aide/src/impls/mod.rs
@@ -16,6 +16,9 @@ mod bytes;
 #[cfg(feature = "http")]
 mod http;
 
+#[cfg(feature = "serde_qs")]
+mod serde_qs;
+
 impl<T, E> OperationInput for Result<T, E>
 where
     T: OperationInput,

--- a/crates/aide/src/impls/serde_qs.rs
+++ b/crates/aide/src/impls/serde_qs.rs
@@ -1,0 +1,31 @@
+use schemars::JsonSchema;
+
+use crate::{
+    openapi::Operation,
+    operation::{add_parameters, parameters_from_schema, ParamLocation},
+    OperationInput,
+};
+
+#[cfg(feature = "axum")]
+impl<T> OperationInput for serde_qs::axum::QsQuery<T>
+where
+    T: JsonSchema,
+{
+    fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
+        let schema = ctx.schema.subschema_for::<T>().into_object();
+        let params = parameters_from_schema(ctx, schema, ParamLocation::Query);
+        add_parameters(ctx, operation, params);
+    }
+}
+
+#[cfg(feature = "axum")]
+impl<T> OperationInput for serde_qs::axum::OptionalQsQuery<T>
+where
+    T: JsonSchema,
+{
+    fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
+        let schema = ctx.schema.subschema_for::<T>().into_object();
+        let params = parameters_from_schema(ctx, schema, ParamLocation::Query);
+        add_parameters(ctx, operation, params);
+    }
+}


### PR DESCRIPTION
serde_qs is released with axum v0.8 support. Let's bring it back to aide.

Additionally implement `OperationInput` for `OptionalQsQuery`, see https://github.com/samscott89/serde_qs/pull/102