### PR TITLE
fix: missing conversion to a `SchemaObject`

### DIFF
--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -189,6 +189,7 @@ use axum::{
 };
 use indexmap::map::Entry;
 use indexmap::IndexMap;
+use schemars::schema::Schema;
 use tower_layer::Layer;
 use tower_service::Service;
 
@@ -452,7 +453,7 @@ where
                             (
                                 name,
                                 SchemaObject {
-                                    json_schema,
+                                    json_schema: Schema::Object(json_schema.into_object()),
                                     example: None,
                                     external_docs: None,
                                 },


### PR DESCRIPTION
The field `json_schema: Schema` on `SchemaObject` has `#[serde(flatten)]`. This is fine if this field is assigned the `Schema::Object(..)` variant, but there's also the other variant `Schema::Bool(bool)` which cannot be flattened. I'd wish to just fix the definition of `SchemaObject` to require a `schemars::schema::SchemaObject` and guarantee that no boolean scheme ever occurs there, but this field is public and thus changing its type is a breaking change. So for now I found a place where a boolean scheme may (and does in practice) occur and added an appropriate conversion.