### PR TITLE
Add axum_extra::extract::Host support

### DIFF
--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -354,6 +354,8 @@ mod extra {
         }
     }
 
+    impl OperationInput for extract::Host {}
+
     #[cfg(feature = "axum-extra-cookie")]
     impl OperationInput for extract::CookieJar {}
 


### PR DESCRIPTION
The impl was removed in the axum 0.8 upgrade due to the type moving to axum-extra.