### PR TITLE
Mention a required feature in axum doc

### DIFF
--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! # Examples
 //!
-//! Take the following `axum` example:
+//! Take the following `axum` example (requires aide's `axum-json` feature):
 //!
 //! ```no_run
 //! use axum::{response::IntoResponse, routing::post, Json, Router};


### PR DESCRIPTION
https://github.com/tamasfe/aide/issues/255

Might be obvious to the devs of this crate, but it took me a stupidly long time - I assumed that copy-pasting from the example page from the `axum` feature would be enough, and the error message you get if you do not enable `axum-json` is rather gnarly.