### PR TITLE
fix(Scalar): default rust-theme font

### DIFF
--- a/crates/aide/res/scalar/rust-theme.css
+++ b/crates/aide/res/scalar/rust-theme.css
@@ -1,5 +1,5 @@
 :root {
-  --scalar-font: "Inter", var(--system-fonts);
+  --scalar-font: "Inter", var(--system-fonts, "sans-serif");
 }
 
 /* basic theme */


### PR DESCRIPTION
closes #226
## Before: 
<img width="1415" height="891" alt="image" src="https://github.com/user-attachments/assets/d22227d2-cd1d-4556-8a9c-5740568a7401" />

## After:
<img width="1417" height="901" alt="image" src="https://github.com/user-attachments/assets/aacc612c-813a-44d7-9e54-88f10ce0a435" />
