### PR TITLE
feat: add support for matched path feature in axum integration

### DIFF
--- a/crates/aide/Cargo.toml
+++ b/crates/aide/Cargo.toml
@@ -34,7 +34,7 @@ redoc = []
 swagger = []
 scalar = []
 skip_serializing_defaults = []
-serde_qs = ["dep:serde_qs"]
+serde_qs = ["dep:serde_qs", "serde_qs/axum"]
 
 axum = ["dep:axum", "bytes", "http", "dep:tower-layer", "dep:tower-service", "serde_qs?/axum"]
 axum-form = ["axum", "axum/form"]

--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -22,6 +22,8 @@ use crate::{
 
 #[cfg(feature = "axum")]
 pub(crate) const MATCHED_PATH_EXTENSION: &str = "x-aide-axum-matched-path";
+#[cfg(feature = "axum")]
+pub(crate) const PATH_INPUT_SCHEMA_EXTENSION: &str = "x-aide-axum-path-input-schema";
 
 impl<T> OperationInput for Extension<T> {}
 impl<T> OperationInput for State<T> {}
@@ -222,6 +224,11 @@ where
 {
     fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
         let schema = ctx.schema.subschema_for::<T>();
+        if let Ok(schema_value) = serde_json::to_value(&schema) {
+            operation
+                .extensions
+                .insert(PATH_INPUT_SCHEMA_EXTENSION.to_string(), schema_value);
+        }
         let params = parameters_from_schema(ctx, schema, ParamLocation::Path);
         add_parameters(ctx, operation, params);
     }

--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -21,8 +21,6 @@ use crate::{
 };
 
 #[cfg(feature = "axum")]
-pub(crate) const MATCHED_PATH_EXTENSION: &str = "x-aide-axum-matched-path";
-#[cfg(feature = "axum")]
 pub(crate) const PATH_INPUT_SCHEMA_EXTENSION: &str = "x-aide-axum-path-input-schema";
 
 impl<T> OperationInput for Extension<T> {}
@@ -33,16 +31,11 @@ impl OperationInput for RawQuery {}
 
 #[cfg(feature = "axum-tokio")]
 impl<T> OperationInput for axum::extract::ConnectInfo<T> {}
-#[cfg(feature = "axum-matched-path")]
-impl OperationInput for axum::extract::MatchedPath {
-    fn operation_input(_ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
-        operation
-            .extensions
-            .insert(MATCHED_PATH_EXTENSION.to_string(), json!(true));
-    }
-}
 #[cfg(feature = "axum-original-uri")]
 impl OperationInput for axum::extract::OriginalUri {}
+
+#[cfg(feature = "axum-matched-path")]
+impl OperationInput for axum::extract::MatchedPath {}
 
 #[cfg(feature = "axum-extra-headers")]
 impl<T> OperationInput for axum_extra::typed_header::TypedHeader<T>

--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -20,6 +20,9 @@ use crate::{
     operation::{parameters_from_schema, OperationInput, ParamLocation},
 };
 
+#[cfg(feature = "axum")]
+pub(crate) const MATCHED_PATH_EXTENSION: &str = "x-aide-axum-matched-path";
+
 impl<T> OperationInput for Extension<T> {}
 impl<T> OperationInput for State<T> {}
 
@@ -29,7 +32,13 @@ impl OperationInput for RawQuery {}
 #[cfg(feature = "axum-tokio")]
 impl<T> OperationInput for axum::extract::ConnectInfo<T> {}
 #[cfg(feature = "axum-matched-path")]
-impl OperationInput for axum::extract::MatchedPath {}
+impl OperationInput for axum::extract::MatchedPath {
+    fn operation_input(_ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
+        operation
+            .extensions
+            .insert(MATCHED_PATH_EXTENSION.to_string(), json!(true));
+    }
+}
 #[cfg(feature = "axum-original-uri")]
 impl OperationInput for axum::extract::OriginalUri {}
 

--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -203,10 +203,13 @@ use crate::openapi::{ParameterData, ParameterSchemaOrContent, PathStyle};
 use crate::{openapi::Parameter, util::iter_operations_mut};
 
 #[cfg(feature = "axum")]
-use schemars::json_schema;
+use schemars::{json_schema, Schema};
 
 #[cfg(feature = "axum")]
-use self::inputs::MATCHED_PATH_EXTENSION;
+use serde_json::Value;
+
+#[cfg(feature = "axum")]
+use self::inputs::{MATCHED_PATH_EXTENSION, PATH_INPUT_SCHEMA_EXTENSION};
 
 mod inputs;
 mod outputs;
@@ -239,53 +242,93 @@ fn extract_path_parameter_names(path: &str) -> Vec<String> {
     names
 }
 
+#[cfg(feature = "axum")]
+fn extract_positional_path_schemas(schema: &Value) -> Vec<Schema> {
+    let to_schema = |value: &Value| value.clone().try_into().ok();
+
+    let Some(schema_object) = schema.as_object() else {
+        return Vec::new();
+    };
+
+    if let Some(prefix_items) = schema_object.get("prefixItems").and_then(Value::as_array) {
+        return prefix_items.iter().filter_map(to_schema).collect();
+    }
+
+    if let Some(items) = schema_object.get("items") {
+        if let Some(items_array) = items.as_array() {
+            return items_array.iter().filter_map(to_schema).collect();
+        }
+    }
+
+    if schema_object.contains_key("properties") {
+        return Vec::new();
+    }
+
+    to_schema(schema).into_iter().collect()
+}
+
+#[cfg(feature = "axum")]
+fn default_path_parameter_schema() -> Schema {
+    json_schema!({
+        "type": "string",
+    })
+}
+
 fn apply_path_template_parameters(path: &str, path_item: &mut PathItem) {
     let path_parameter_names = extract_path_parameter_names(path);
 
     for (_, operation) in iter_operations_mut(path_item) {
         #[cfg(feature = "axum")]
         {
+            let typed_path_schemas = operation
+                .extensions
+                .swap_remove(PATH_INPUT_SCHEMA_EXTENSION)
+                .map(|schema| extract_positional_path_schemas(&schema))
+                .unwrap_or_default();
+
             let _ = operation.extensions.swap_remove(MATCHED_PATH_EXTENSION);
-        }
 
-        for parameter_name in &path_parameter_names {
-            let already_exists = operation.parameters.iter().any(|parameter| {
-                matches!(
-                    parameter,
-                    ReferenceOr::Item(Parameter::Path {
-                        parameter_data,
-                        style: _,
-                    }) if parameter_data.name == *parameter_name
-                )
-            });
+            for (parameter_index, parameter_name) in path_parameter_names.iter().enumerate() {
+                let already_exists = operation.parameters.iter().any(|parameter| {
+                    matches!(
+                        parameter,
+                        ReferenceOr::Item(Parameter::Path {
+                            parameter_data,
+                            style: _,
+                        }) if parameter_data.name == *parameter_name
+                    )
+                });
 
-            if already_exists {
-                continue;
-            }
+                if already_exists {
+                    continue;
+                }
 
-            #[cfg(feature = "axum")]
-            operation
-                .parameters
-                .push(ReferenceOr::Item(Parameter::Path {
-                    parameter_data: ParameterData {
-                        name: parameter_name.clone(),
-                        description: None,
-                        required: true,
-                        format: ParameterSchemaOrContent::Schema(SchemaObject {
-                            json_schema: json_schema!({
-                                "type": "string",
+                let json_schema = typed_path_schemas
+                    .get(parameter_index)
+                    .cloned()
+                    .unwrap_or_else(default_path_parameter_schema);
+
+                operation
+                    .parameters
+                    .push(ReferenceOr::Item(Parameter::Path {
+                        parameter_data: ParameterData {
+                            name: parameter_name.clone(),
+                            description: None,
+                            required: true,
+                            format: ParameterSchemaOrContent::Schema(SchemaObject {
+                                json_schema,
+                                example: None,
+                                external_docs: None,
                             }),
+                            extensions: Default::default(),
+                            deprecated: None,
                             example: None,
-                            external_docs: None,
-                        }),
-                        extensions: Default::default(),
-                        deprecated: None,
-                        example: None,
-                        examples: Default::default(),
-                        explode: None,
-                    },
-                    style: PathStyle::Simple,
-                }));
+                            examples: Default::default(),
+                            explode: None,
+                        },
+                        style: PathStyle::Simple,
+                    }));
+            }
         }
     }
 }
@@ -991,7 +1034,7 @@ where
 mod tests {
     use crate::axum::{routing, ApiRouter};
     #[cfg(feature = "axum")]
-    use crate::openapi::{Parameter, ReferenceOr};
+    use crate::openapi::{Parameter, ParameterData, ParameterSchemaOrContent, ReferenceOr};
     use axum::{extract::State, handler::Handler};
 
     async fn test_handler1(State(_): State<TestState>) {}
@@ -1000,6 +1043,9 @@ mod tests {
     async fn test_handler3() {}
     #[cfg(feature = "axum")]
     async fn test_handler5(_id: axum::extract::Path<u32>) {}
+
+    #[cfg(feature = "axum")]
+    async fn test_handler6(_params: axum::extract::Path<(bool, u32)>) {}
 
     #[cfg(feature = "axum-matched-path")]
     async fn test_handler4(_matched_path: axum::extract::MatchedPath) {}
@@ -1119,6 +1165,18 @@ mod tests {
     }
 
     #[cfg(feature = "axum")]
+    fn schema_type(parameter_data: &ParameterData) -> Option<&str> {
+        let ParameterSchemaOrContent::Schema(schema) = &parameter_data.format else {
+            return None;
+        };
+
+        schema
+            .json_schema
+            .get("type")
+            .and_then(|value| value.as_str())
+    }
+
+    #[cfg(feature = "axum")]
     #[test]
     fn test_path_template_generates_path_parameters_without_matched_path() {
         let app: ApiRouter = ApiRouter::new().api_route("/users/{id}", routing::get(test_handler5));
@@ -1144,6 +1202,38 @@ mod tests {
         assert_eq!(path_params.len(), 1);
         assert_eq!(path_params[0].name, "id");
         assert!(path_params[0].required);
+        assert_eq!(schema_type(path_params[0]), Some("integer"));
+    }
+
+    #[cfg(feature = "axum")]
+    #[test]
+    fn test_tuple_path_parameters_keep_type_information() {
+        let app: ApiRouter =
+            ApiRouter::new().api_route("/users/{flag}/{count}", routing::get(test_handler6));
+
+        let operation = app
+            .paths
+            .get("/users/{flag}/{count}")
+            .and_then(|path| path.get.as_ref())
+            .expect("expected GET operation for /users/{flag}/{count}");
+
+        let path_params = operation
+            .parameters
+            .iter()
+            .filter_map(|parameter| match parameter {
+                ReferenceOr::Item(Parameter::Path {
+                    parameter_data,
+                    style: _,
+                }) => Some(parameter_data),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(path_params.len(), 2);
+        assert_eq!(path_params[0].name, "flag");
+        assert_eq!(schema_type(path_params[0]), Some("boolean"));
+        assert_eq!(path_params[1].name, "count");
+        assert_eq!(schema_type(path_params[1]), Some("integer"));
     }
 
     #[cfg(feature = "axum-matched-path")]

--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -209,7 +209,7 @@ use schemars::{json_schema, Schema};
 use serde_json::Value;
 
 #[cfg(feature = "axum")]
-use self::inputs::{MATCHED_PATH_EXTENSION, PATH_INPUT_SCHEMA_EXTENSION};
+use self::inputs::PATH_INPUT_SCHEMA_EXTENSION;
 
 mod inputs;
 mod outputs;
@@ -285,8 +285,6 @@ fn apply_path_template_parameters(path: &str, path_item: &mut PathItem) {
                 .swap_remove(PATH_INPUT_SCHEMA_EXTENSION)
                 .map(|schema| extract_positional_path_schemas(&schema))
                 .unwrap_or_default();
-
-            let _ = operation.extensions.swap_remove(MATCHED_PATH_EXTENSION);
 
             for (parameter_index, parameter_name) in path_parameter_names.iter().enumerate() {
                 let already_exists = operation.parameters.iter().any(|parameter| {
@@ -1246,13 +1244,6 @@ mod tests {
             .get("/users/{id}")
             .and_then(|path| path.get.as_ref())
             .expect("expected GET operation for /users/{id}");
-
-        assert!(
-            !operation
-                .extensions
-                .contains_key(super::MATCHED_PATH_EXTENSION),
-            "internal matched-path marker must not leak into generated OpenAPI"
-        );
 
         let path_params = operation
             .parameters

--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -198,10 +198,97 @@ use axum_extra::routing::RouterExt as _;
 use self::routing::ApiMethodRouter;
 use crate::transform::{TransformOpenApi, TransformPathItem};
 
+#[cfg(feature = "axum")]
+use crate::openapi::{ParameterData, ParameterSchemaOrContent, PathStyle};
+use crate::{openapi::Parameter, util::iter_operations_mut};
+
+#[cfg(feature = "axum")]
+use schemars::json_schema;
+
+#[cfg(feature = "axum")]
+use self::inputs::MATCHED_PATH_EXTENSION;
+
 mod inputs;
 mod outputs;
 
 pub mod routing;
+
+fn extract_path_parameter_names(path: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut current = String::new();
+    let mut in_param = false;
+
+    for ch in path.chars() {
+        match ch {
+            '{' if !in_param => {
+                in_param = true;
+                current.clear();
+            }
+            '}' if in_param => {
+                let normalized = current.trim().trim_start_matches('*');
+                if !normalized.is_empty() && !names.iter().any(|name| name == normalized) {
+                    names.push(normalized.to_string());
+                }
+                in_param = false;
+            }
+            _ if in_param => current.push(ch),
+            _ => {}
+        }
+    }
+
+    names
+}
+
+fn apply_path_template_parameters(path: &str, path_item: &mut PathItem) {
+    let path_parameter_names = extract_path_parameter_names(path);
+
+    for (_, operation) in iter_operations_mut(path_item) {
+        #[cfg(feature = "axum")]
+        {
+            let _ = operation.extensions.swap_remove(MATCHED_PATH_EXTENSION);
+        }
+
+        for parameter_name in &path_parameter_names {
+            let already_exists = operation.parameters.iter().any(|parameter| {
+                matches!(
+                    parameter,
+                    ReferenceOr::Item(Parameter::Path {
+                        parameter_data,
+                        style: _,
+                    }) if parameter_data.name == *parameter_name
+                )
+            });
+
+            if already_exists {
+                continue;
+            }
+
+            #[cfg(feature = "axum")]
+            operation
+                .parameters
+                .push(ReferenceOr::Item(Parameter::Path {
+                    parameter_data: ParameterData {
+                        name: parameter_name.clone(),
+                        description: None,
+                        required: true,
+                        format: ParameterSchemaOrContent::Schema(SchemaObject {
+                            json_schema: json_schema!({
+                                "type": "string",
+                            }),
+                            example: None,
+                            external_docs: None,
+                        }),
+                        extensions: Default::default(),
+                        deprecated: None,
+                        example: None,
+                        examples: Default::default(),
+                        explode: None,
+                    },
+                    style: PathStyle::Simple,
+                }));
+        }
+    }
+}
 
 #[cfg(all(feature = "macros", feature = "axum-extra-typed-routing"))]
 pub use aide_macros::axum_typed_path as typed_path;
@@ -300,7 +387,8 @@ where
     #[tracing::instrument(skip_all, fields(path = path))]
     pub fn api_route(mut self, path: &str, mut method_router: ApiMethodRouter<S>) -> Self {
         in_context(|ctx| {
-            let new_path_item = method_router.take_path_item();
+            let mut new_path_item = method_router.take_path_item();
+            apply_path_template_parameters(path, &mut new_path_item);
 
             if let Some(path_item) = self.paths.get_mut(path) {
                 merge_paths(ctx, path, path_item, new_path_item);
@@ -323,7 +411,8 @@ where
     #[tracing::instrument(skip_all, fields(path = path))]
     pub fn api_route_with_tsr(mut self, path: &str, mut method_router: ApiMethodRouter<S>) -> Self {
         in_context(|ctx| {
-            let new_path_item = method_router.take_path_item();
+            let mut new_path_item = method_router.take_path_item();
+            apply_path_template_parameters(path, &mut new_path_item);
 
             if let Some(path_item) = self.paths.get_mut(path) {
                 merge_paths(ctx, path, path_item, new_path_item);
@@ -352,6 +441,8 @@ where
     ) -> Self {
         in_context(|ctx| {
             let mut p = method_router.take_path_item();
+            apply_path_template_parameters(path, &mut p);
+
             let t = transform(TransformPathItem::new(&mut p));
 
             if !t.hidden {
@@ -384,6 +475,8 @@ where
     ) -> Self {
         in_context(|ctx| {
             let mut p = method_router.take_path_item();
+            apply_path_template_parameters(path, &mut p);
+
             let t = transform(TransformPathItem::new(&mut p));
 
             if !t.hidden {
@@ -485,9 +578,12 @@ where
         in_context(|_ctx| {
             if let Some(path_item) = self.paths.get_mut(path) {
                 docs.apply_to_path_item(path_item);
+                apply_path_template_parameters(path, path_item);
             } else {
                 let mut path_item = PathItem::default();
                 docs.apply_to_path_item(&mut path_item);
+                apply_path_template_parameters(path, &mut path_item);
+
                 self.paths.insert(path.into(), path_item);
             }
         });
@@ -511,10 +607,14 @@ where
             let mut path_item = if let Some(existing) = self.paths.get_mut(path) {
                 let mut new_item = existing.clone();
                 docs.apply_to_path_item(&mut new_item);
+                apply_path_template_parameters(path, &mut new_item);
+
                 new_item
             } else {
                 let mut new_item = PathItem::default();
                 docs.apply_to_path_item(&mut new_item);
+                apply_path_template_parameters(path, &mut new_item);
+
                 new_item
             };
             let _ = transform(TransformPathItem::new(&mut path_item));
@@ -890,12 +990,19 @@ where
 #[allow(clippy::unused_async)]
 mod tests {
     use crate::axum::{routing, ApiRouter};
+    #[cfg(feature = "axum")]
+    use crate::openapi::{Parameter, ReferenceOr};
     use axum::{extract::State, handler::Handler};
 
     async fn test_handler1(State(_): State<TestState>) {}
     async fn test_handler2(State(_): State<u8>) {}
 
     async fn test_handler3() {}
+    #[cfg(feature = "axum")]
+    async fn test_handler5(_id: axum::extract::Path<u32>) {}
+
+    #[cfg(feature = "axum-matched-path")]
+    async fn test_handler4(_matched_path: axum::extract::MatchedPath) {}
 
     #[cfg(feature = "axum-json")]
     #[test]
@@ -1009,5 +1116,68 @@ mod tests {
             "/test-route",
             routing::get(test_handler3.layer(tower_layer::Identity::new())),
         );
+    }
+
+    #[cfg(feature = "axum")]
+    #[test]
+    fn test_path_template_generates_path_parameters_without_matched_path() {
+        let app: ApiRouter = ApiRouter::new().api_route("/users/{id}", routing::get(test_handler5));
+
+        let operation = app
+            .paths
+            .get("/users/{id}")
+            .and_then(|path| path.get.as_ref())
+            .expect("expected GET operation for /users/{id}");
+
+        let path_params = operation
+            .parameters
+            .iter()
+            .filter_map(|parameter| match parameter {
+                ReferenceOr::Item(Parameter::Path {
+                    parameter_data,
+                    style: _,
+                }) => Some(parameter_data),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(path_params.len(), 1);
+        assert_eq!(path_params[0].name, "id");
+        assert!(path_params[0].required);
+    }
+
+    #[cfg(feature = "axum-matched-path")]
+    #[test]
+    fn test_matched_path_generates_path_parameters() {
+        let app: ApiRouter = ApiRouter::new().api_route("/users/{id}", routing::get(test_handler4));
+
+        let operation = app
+            .paths
+            .get("/users/{id}")
+            .and_then(|path| path.get.as_ref())
+            .expect("expected GET operation for /users/{id}");
+
+        assert!(
+            !operation
+                .extensions
+                .contains_key(super::MATCHED_PATH_EXTENSION),
+            "internal matched-path marker must not leak into generated OpenAPI"
+        );
+
+        let path_params = operation
+            .parameters
+            .iter()
+            .filter_map(|parameter| match parameter {
+                ReferenceOr::Item(Parameter::Path {
+                    parameter_data,
+                    style: _,
+                }) => Some(parameter_data),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(path_params.len(), 1);
+        assert_eq!(path_params[0].name, "id");
+        assert!(path_params[0].required);
     }
 }

--- a/crates/aide/src/impls/serde_qs.rs
+++ b/crates/aide/src/impls/serde_qs.rs
@@ -6,7 +6,6 @@ use crate::{
     OperationInput,
 };
 
-#[cfg(feature = "axum")]
 impl<T> OperationInput for serde_qs::axum::QsQuery<T>
 where
     T: JsonSchema,

--- a/crates/aide/src/redoc/mod.rs
+++ b/crates/aide/src/redoc/mod.rs
@@ -182,6 +182,7 @@ mod axum_impl {
     }
 }
 
+#[cfg(feature = "axum")]
 fn get_static_str(string: String) -> &'static str {
     let static_str = Box::leak(string.into_boxed_str());
     static_str

--- a/crates/aide/src/swagger/mod.rs
+++ b/crates/aide/src/swagger/mod.rs
@@ -192,6 +192,7 @@ mod axum_impl {
     }
 }
 
+#[cfg(feature = "axum")]
 fn get_static_str(string: String) -> &'static str {
     let static_str = Box::leak(string.into_boxed_str());
     static_str


### PR DESCRIPTION
This change enable the path params into Swagger, Scalar and Redocs:

<details>

<summary>Scalar</summary>

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>


<img width="758" height="242" alt="image" src="https://github.com/user-attachments/assets/63725d57-e80c-4238-8ba3-95ba7e315b9c" />
</td>
<td>
<img width="783" height="306" alt="image" src="https://github.com/user-attachments/assets/e6b11b06-c135-43ac-bcbf-4eda95902744" />


</td>
</tr>
</table>

</details>


<details>

<summary>Swagger</summary>

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

<img width="676" height="416" alt="image" src="https://github.com/user-attachments/assets/6344b7c7-9330-4293-9811-6095d56139d8" />

</td>
<td>
<img width="1439" height="592" alt="image" src="https://github.com/user-attachments/assets/1885061c-e660-42ff-9b08-28a7964533d0" />

</td>
</tr>
</table>

</details>


<details>

<summary>Redocs</summary>

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

<img width="943" height="231" alt="image" src="https://github.com/user-attachments/assets/523b964e-10bd-40fd-971b-34e1aa00928b" />

</td>
<td>

<img width="965" height="325" alt="image" src="https://github.com/user-attachments/assets/f4c3a631-7507-4542-8399-ec2b4de63ff9" />

</td>
</tr>
</table>
</details>