### PR TITLE
fix(aide): apply schemars transforms to inlined schemas

### DIFF
--- a/crates/aide/src/axum/inputs.rs
+++ b/crates/aide/src/axum/inputs.rs
@@ -39,7 +39,8 @@ where
     T: axum_extra::headers::Header,
 {
     fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
-        let s = ctx.schema.subschema_for::<String>();
+        let mut s = ctx.schema.subschema_for::<String>();
+        ctx.apply_transforms(&mut s);
         add_parameters(
             ctx,
             operation,
@@ -72,17 +73,19 @@ fn operation_input_json<T: JsonSchema>(
     ctx: &mut crate::generate::GenContext,
     operation: &mut Operation,
 ) {
-    let json_schema = ctx.schema.subschema_for::<T>();
-    let resolved_schema = ctx.resolve_schema(&json_schema);
+    let mut json_schema = ctx.schema.subschema_for::<T>();
+    let description = ctx
+        .resolve_schema(&json_schema)
+        .get("description")
+        .and_then(|d| d.as_str())
+        .map(String::from);
+    ctx.apply_transforms(&mut json_schema);
 
     set_body(
         ctx,
         operation,
         RequestBody {
-            description: resolved_schema
-                .get("description")
-                .and_then(|d| d.as_str())
-                .map(String::from),
+            description,
             content: IndexMap::from_iter([(
                 "application/json".into(),
                 MediaType {
@@ -178,17 +181,19 @@ where
     T: JsonSchema,
 {
     fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
-        let schema = ctx.schema.subschema_for::<T>();
-        let resolved_schema = ctx.resolve_schema(&schema);
+        let mut schema = ctx.schema.subschema_for::<T>();
+        let description = ctx
+            .resolve_schema(&schema)
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(String::from);
+        ctx.apply_transforms(&mut schema);
 
         set_body(
             ctx,
             operation,
             RequestBody {
-                description: resolved_schema
-                    .get("description")
-                    .and_then(|d| d.as_str())
-                    .map(String::from),
+                description,
                 content: IndexMap::from_iter([(
                     "application/x-www-form-urlencoded".into(),
                     MediaType {
@@ -412,17 +417,19 @@ where
     T: JsonSchema,
 {
     fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
-        let schema = ctx.schema.subschema_for::<T>();
-        let resolved_schema = ctx.resolve_schema(&schema);
+        let mut schema = ctx.schema.subschema_for::<T>();
+        let description = ctx
+            .resolve_schema(&schema)
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(String::from);
+        ctx.apply_transforms(&mut schema);
 
         set_body(
             ctx,
             operation,
             RequestBody {
-                description: resolved_schema
-                    .get("description")
-                    .and_then(|d| d.as_str())
-                    .map(String::from),
+                description,
                 content: IndexMap::from_iter([(
                     "application/x-www-form-urlencoded".into(),
                     MediaType {

--- a/crates/aide/src/axum/mod.rs
+++ b/crates/aide/src/axum/mod.rs
@@ -937,6 +937,112 @@ mod tests {
         });
     }
 
+    /// The schema generator's transforms must be applied to request body
+    /// schemas that are inlined into the document.
+    ///
+    /// With `extract_schemas` disabled the body schema is embedded verbatim
+    /// rather than as a `$ref`, so nothing else will ever transform it. `aide`
+    /// defaults to draft 7, which has no `prefixItems` keyword, and a tuple is
+    /// inlined by `schemars` rather than extracted into its own definition.
+    #[cfg(feature = "axum-json")]
+    #[test]
+    fn inlined_request_body_has_generator_transforms_applied() {
+        use crate::{generate, openapi::Operation, OperationInput};
+        use axum::Json;
+        use schemars::JsonSchema;
+
+        #[derive(JsonSchema)]
+        #[allow(dead_code)]
+        struct Body {
+            range: (u8, u8),
+        }
+
+        generate::extract_schemas(false);
+        let mut operation = Operation::default();
+        generate::in_context(|ctx| {
+            <Json<Body> as OperationInput>::operation_input(ctx, &mut operation);
+        });
+        generate::reset_context();
+
+        let body = operation
+            .request_body
+            .expect("request body")
+            .into_item()
+            .expect("inline request body");
+        let schema = &body.content["application/json"]
+            .schema
+            .as_ref()
+            .expect("schema")
+            .json_schema;
+
+        let range = schema
+            .get("properties")
+            .and_then(|p| p.get("range"))
+            .expect("`range` property");
+        assert_eq!(
+            range.get("prefixItems"),
+            None,
+            "`prefixItems` is not valid in draft 7 and should have been transformed away"
+        );
+        assert!(
+            range.get("items").is_some(),
+            "`prefixItems` should have been rewritten to `items`, got {range:?}"
+        );
+    }
+
+    /// `TypedHeader` embeds a generated `String` schema straight into a header
+    /// parameter, so it needs the generator's transforms like every other
+    /// inline embedding site.
+    #[cfg(feature = "axum-extra-headers")]
+    #[test]
+    fn typed_header_schema_has_generator_transforms_applied() {
+        use crate::{generate, openapi::Operation, OperationInput};
+        use axum_extra::typed_header::TypedHeader;
+        use schemars::transform::Transform;
+
+        #[derive(Debug, Clone)]
+        struct Marker;
+
+        impl Transform for Marker {
+            fn transform(&mut self, schema: &mut schemars::Schema) {
+                schemars::transform::transform_subschemas(self, schema);
+                schema.insert("x-marked".to_owned(), true.into());
+            }
+        }
+
+        let mut operation = Operation::default();
+        generate::in_context(|ctx| {
+            let settings = schemars::generate::SchemaSettings::draft07()
+                .with(|s| s.transforms = vec![Box::new(Marker)]);
+            ctx.schema = schemars::SchemaGenerator::new(settings);
+
+            <TypedHeader<axum_extra::headers::ContentType> as OperationInput>::operation_input(
+                ctx,
+                &mut operation,
+            );
+        });
+        generate::reset_context();
+
+        let param = operation
+            .parameters
+            .first()
+            .expect("one header parameter")
+            .as_item()
+            .expect("inline parameter");
+        let crate::openapi::ParameterSchemaOrContent::Schema(schema) =
+            &param.parameter_data_ref().format
+        else {
+            panic!("expected a schema, not content");
+        };
+
+        assert_eq!(
+            schema.json_schema.get("x-marked"),
+            Some(&serde_json::json!(true)),
+            "generator transforms should reach the header schema, got {:?}",
+            schema.json_schema
+        );
+    }
+
     fn nested_route() -> ApiRouter {
         ApiRouter::new()
             .api_route_with("/", routing::post(test_handler3), |t| t)

--- a/crates/aide/src/axum/outputs.rs
+++ b/crates/aide/src/axum/outputs.rs
@@ -37,15 +37,17 @@ where
     type Inner = T;
 
     fn operation_response(ctx: &mut GenContext, _operation: &mut Operation) -> Option<Response> {
-        let json_schema = ctx.schema.subschema_for::<T>();
-        let resolved_schema = ctx.resolve_schema(&json_schema);
+        let mut json_schema = ctx.schema.subschema_for::<T>();
+        let description = ctx
+            .resolve_schema(&json_schema)
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(String::from)
+            .unwrap_or_default();
+        ctx.apply_transforms(&mut json_schema);
 
         Some(Response {
-            description: resolved_schema
-                .get("description")
-                .and_then(|d| d.as_str())
-                .map(String::from)
-                .unwrap_or_default(),
+            description,
             content: IndexMap::from_iter([(
                 "application/json".into(),
                 MediaType {
@@ -91,15 +93,17 @@ where
     type Inner = T;
 
     fn operation_response(ctx: &mut GenContext, _operation: &mut Operation) -> Option<Response> {
-        let json_schema = ctx.schema.subschema_for::<T>();
-        let resolved_schema = ctx.resolve_schema(&json_schema);
+        let mut json_schema = ctx.schema.subschema_for::<T>();
+        let description = ctx
+            .resolve_schema(&json_schema)
+            .get("description")
+            .and_then(|d| d.as_str())
+            .map(String::from)
+            .unwrap_or_default();
+        ctx.apply_transforms(&mut json_schema);
 
         Some(Response {
-            description: resolved_schema
-                .get("description")
-                .and_then(|d| d.as_str())
-                .map(String::from)
-                .unwrap_or_default(),
+            description,
             content: IndexMap::from_iter([(
                 "application/x-www-form-urlencoded".into(),
                 MediaType {

--- a/crates/aide/src/axum/routing/typed.rs
+++ b/crates/aide/src/axum/routing/typed.rs
@@ -301,11 +301,17 @@ where
 {
     fn operation_input(ctx: &mut crate::generate::GenContext, operation: &mut Operation) {
         // `subschema_for` `description` is none, while `root_schema_for` is some
-        let schema = ctx.schema.root_schema_for::<T>();
-        operation.description = schema
+        let root_schema = ctx.schema.root_schema_for::<T>();
+        operation.description = root_schema
             .get("description")
             .and_then(|d| d.as_str())
             .map(String::from);
+
+        // Take the parameters from `subschema_for` rather than reusing the root
+        // schema: `root_schema_for` has already applied the generator's
+        // transforms, and `parameters_from_schema` applies them again, so
+        // passing the root schema here would transform it twice.
+        let schema = ctx.schema.subschema_for::<T>();
         let params = parameters_from_schema(ctx, schema, ParamLocation::Path);
         add_parameters(ctx, operation, params);
     }
@@ -337,5 +343,85 @@ where
     ) -> Result<Option<Self>, Self::Rejection> {
         let path = axum::extract::Path::<T>::from_request_parts(parts, state).await?;
         Ok(path.map(|x| Self(x.0)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypedPath;
+    use crate::{generate, openapi::Operation, OperationInput};
+    use schemars::{transform::Transform, JsonSchema};
+
+    /// Records how many times the generator's transforms have run over a schema.
+    #[derive(Debug, Clone)]
+    struct CountPasses;
+
+    impl Transform for CountPasses {
+        fn transform(&mut self, schema: &mut schemars::Schema) {
+            schemars::transform::transform_subschemas(self, schema);
+            let passes = schema
+                .get("x-passes")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            schema.insert("x-passes".to_owned(), (passes + 1).into());
+        }
+    }
+
+    #[derive(JsonSchema)]
+    #[allow(dead_code)]
+    struct UserPath {
+        id: String,
+    }
+
+    impl std::fmt::Display for UserPath {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("/users/x")
+        }
+    }
+
+    impl axum_extra::routing::TypedPath for UserPath {
+        const PATH: &'static str = "/users/{id}";
+    }
+
+    /// `TypedPath` reads the operation description out of `root_schema_for`,
+    /// which has already applied the generator's transforms. The parameters must
+    /// not be taken from that same schema, or every transform runs twice.
+    ///
+    /// Transforms are not required to be idempotent, so a second pass can
+    /// corrupt the parameter schemas rather than merely repeat work.
+    #[test]
+    fn typed_path_parameters_are_transformed_exactly_once() {
+        let mut operation = Operation::default();
+
+        generate::in_context(|ctx| {
+            let settings = schemars::generate::SchemaSettings::draft07().with(|s| {
+                s.inline_subschemas = false;
+                s.definitions_path = "#/components/schemas/".into();
+                s.transforms = vec![Box::new(CountPasses)];
+            });
+            ctx.schema = schemars::SchemaGenerator::new(settings);
+
+            <TypedPath<UserPath> as OperationInput>::operation_input(ctx, &mut operation);
+        });
+        generate::reset_context();
+
+        let param = operation
+            .parameters
+            .first()
+            .expect("one path parameter")
+            .as_item()
+            .expect("inline parameter");
+        let crate::openapi::ParameterSchemaOrContent::Schema(schema) =
+            &param.parameter_data_ref().format
+        else {
+            panic!("expected a schema, not content");
+        };
+
+        assert_eq!(
+            schema.json_schema.get("x-passes"),
+            Some(&serde_json::json!(1)),
+            "transforms should run exactly once, got {:?}",
+            schema.json_schema
+        );
     }
 }

--- a/crates/aide/src/generate.rs
+++ b/crates/aide/src/generate.rs
@@ -212,6 +212,39 @@ impl GenContext {
             _ => schema_or_ref,
         }
     }
+
+    /// Resolve a schema reference and apply the schema generator's
+    /// transforms to the result.
+    ///
+    /// Unlike [`resolve_schema`](Self::resolve_schema) this returns an owned
+    /// schema, because the transforms mutate it.
+    ///
+    /// Use this instead of [`resolve_schema`](Self::resolve_schema) whenever
+    /// the resolved schema is embedded into the documentation directly rather
+    /// than as a reference. `schemars` only applies the transforms configured
+    /// in its settings when generating root schemas or when taking the
+    /// definitions out of the generator, so schemas that `aide` inlines would
+    /// otherwise ignore those settings entirely.
+    #[must_use]
+    pub fn resolve_schema_transformed(&mut self, schema_or_ref: &Schema) -> Schema {
+        let mut schema = self.resolve_schema(schema_or_ref).clone();
+        self.apply_transforms(&mut schema);
+        schema
+    }
+
+    /// Apply the schema generator's transforms to a generated schema in place.
+    ///
+    /// Schema references are left untouched, as the definitions they point at
+    /// are transformed when they are merged into the documentation.
+    pub fn apply_transforms(&mut self, schema: &mut Schema) {
+        if schema.as_object().is_some_and(|o| o.contains_key("$ref")) {
+            return;
+        }
+
+        for transform in self.schema.transforms_mut() {
+            transform.transform(schema);
+        }
+    }
 }
 
 fn default_error_filter(_: &Error) -> bool {

--- a/crates/aide/src/operation.rs
+++ b/crates/aide/src/operation.rs
@@ -204,7 +204,7 @@ pub fn parameters_from_schema(
     schema: Schema,
     location: ParamLocation,
 ) -> Vec<Parameter> {
-    let schema = ctx.resolve_schema(&schema);
+    let schema = ctx.resolve_schema_transformed(&schema);
 
     let mut params = Vec::new();
 
@@ -373,8 +373,9 @@ pub fn add_parameters(
 
 #[cfg(test)]
 mod tests {
+    use super::{parameters_from_schema, ParamLocation};
     use crate::generate::GenContext;
-    use crate::openapi::{Operation, Response, StatusCode};
+    use crate::openapi::{Operation, Parameter, ParameterSchemaOrContent, Response, StatusCode};
     use crate::{generate, OperationInput, OperationOutput};
     use aide_macros::OperationIo;
     use schemars::JsonSchema;
@@ -519,5 +520,48 @@ mod tests {
 
         fn assert_impls_operation_input_output<T: OperationInput + OperationOutput>() {}
         assert_impls_operation_input_output::<OperationInputOutput<(), i32>>();
+    }
+
+    /// The schema generator's transforms must be applied to the schemas that
+    /// end up inlined in a parameter, not just to the extracted definitions.
+    ///
+    /// `aide` defaults to [`schemars::generate::SchemaSettings::draft07`], and
+    /// draft 7 has no `prefixItems` keyword, so its `ReplacePrefixItems`
+    /// transform rewrites `prefixItems` into `items`. A tuple is inlined by
+    /// `schemars` rather than being extracted into its own definition, which
+    /// makes it a direct probe for the inlined code path.
+    #[test]
+    fn parameters_have_generator_transforms_applied() {
+        #[derive(JsonSchema)]
+        #[allow(dead_code)]
+        struct Params {
+            range: (u8, u8),
+        }
+
+        let params = generate::in_context(|ctx| {
+            let schema = ctx.schema.subschema_for::<Params>();
+            parameters_from_schema(ctx, schema, ParamLocation::Query)
+        });
+        generate::reset_context();
+
+        let [Parameter::Query { parameter_data, .. }] = params.as_slice() else {
+            panic!("expected exactly one query parameter, got {params:?}");
+        };
+        assert_eq!(parameter_data.name, "range");
+
+        let ParameterSchemaOrContent::Schema(schema) = &parameter_data.format else {
+            panic!("expected a schema, not content");
+        };
+
+        assert_eq!(
+            schema.json_schema.get("prefixItems"),
+            None,
+            "`prefixItems` is not valid in draft 7 and should have been transformed away"
+        );
+        assert!(
+            schema.json_schema.get("items").is_some(),
+            "`prefixItems` should have been rewritten to `items`, got {:?}",
+            schema.json_schema
+        );
     }
 }


### PR DESCRIPTION
Supersedes #230, part of #270.

As @Diggsey made the original report and analysis, I made him co-author on the commit.

## Intent

aide never applies its schemars settings to the schemas it inlines.

schemars runs the transforms from `SchemaSettings` in two places, `root_schema_for` and `take_definitions(true)`, and aide uses neither when building an operation. It calls `subschema_for::<T>()` and reads the result back through `GenContext::resolve_schema`, which is a plain lookup. Nothing on that path transforms anything. ([Diggsey's description on #230](https://github.com/tamasfe/aide/pull/230#issuecomment-3053804252).)

You don't need custom settings to hit this. aide's own generator is built from `SchemaSettings::draft07()`, which already ships `ReplacePrefixItems` and friends, so a `Query<T>` over

```rust
struct Params { range: (u8, u8) }
```

emits `prefixItems` into a document that announces draft 7. Validators ignore keywords they don't know, so that parameter accepts any array at all. Definitions under `#/components/schemas` were always fine since `merge_api_with` collects them with `take_definitions(true)`; only the inlined half was wrong.

## Proposed Changes

`GenContext` gets `resolve_schema_transformed` (resolve a ref, return a transformed copy) and `apply_transforms` (transform in place). Every site that embeds a generated schema now uses one: `parameters_from_schema`, the media types for `Json` and both `Form`s, and `TypedHeader`.

`apply_transforms` skips `$ref`s on purpose. They have to stay references, and their targets get transformed at merge time. That's also what makes one path work under both `extract_schemas` modes.

`TypedPath` had the reverse problem. It reads its description from `root_schema_for`, which *does* transform, then reused that schema for the parameters, so they'd now be transformed twice. `Transform` promises nothing about idempotency, so it takes parameters from `subschema_for` like every other caller.

Two differences from #230. Its `parameters_from_schema` change is here as-is. Its `axum/inputs.rs` change isn't: at that site the resolved schema is only read for `.get("description")` while the `MediaType` gets the untouched `json_schema`, so the transformed clone was discarded two lines later. I transformed the schema that actually gets embedded instead. That same shape turned up in five more places #230 missed (both `Form` inputs, both `operation_response` impls, `TypedHeader`), all fixed here.

## Breaking Changes

None to the API, both methods are additive. Tested on both schemars 1.0.4 and 1.2.2.